### PR TITLE
Use origin faucet instead of our fork

### DIFF
--- a/ansible/roles/multifaucet/templates/multifaucet/Dockerfile
+++ b/ansible/roles/multifaucet/templates/multifaucet/Dockerfile
@@ -6,8 +6,8 @@ RUN apt-get update && apt-get install -y libpng12-0 libjpeg62-turbo libpng-dev l
   && apt-get remove -y libpng-dev libjpeg-dev libfreetype6-dev \
   && rm -fr /var/cache/apt/*
 
-ENV MULTIFAUCET_COMMIT=f6c1b51562db4e5337502d75967376c06f9286b3
-RUN curl -L -o /tmp/multifaucet.tar.gz https://github.com/dashevo/multifaucet/archive/$MULTIFAUCET_COMMIT.tar.gz \
+ENV MULTIFAUCET_COMMIT=5c625ee79be085c80f09098c6ee8213c0ef3c633
+RUN curl -L -o /tmp/multifaucet.tar.gz https://github.com/tuaris/multifaucet/archive/$MULTIFAUCET_COMMIT.tar.gz \
   && cd /tmp \
   && tar xzf multifaucet.tar.gz \
   && mv multifaucet-$MULTIFAUCET_COMMIT/* /var/www/html/ \


### PR DESCRIPTION
Fixing of multifaucet is a wasting of time so we get rid of our fork and come back to tuaris's origin version https://github.com/tuaris/multifaucet