### PR TITLE
Use multiple subnets for deploy

### DIFF
--- a/terraform/aws/instances.tf
+++ b/terraform/aws/instances.tf
@@ -16,7 +16,7 @@ resource "aws_instance" "web" {
     aws_security_group.http.id,
   ]
 
-  subnet_id = aws_subnet.default.id
+  subnet_id = "${element(aws_subnet.public.*.id, count.index)}"
 
   tags = {
     Name        = "dn-${terraform.workspace}-web-${count.index + 1}"
@@ -38,7 +38,7 @@ resource "aws_instance" "dashd_wallet" {
     aws_security_group.dashd_private.id,
   ]
 
-  subnet_id = aws_subnet.default.id
+  subnet_id = "${element(aws_subnet.public.*.id, count.index)}"
 
   tags = {
     Name        = "dn-${terraform.workspace}-dashd-wallet-${count.index + 1}"
@@ -60,7 +60,7 @@ resource "aws_instance" "dashd_full_node" {
     aws_security_group.dashd_public.id,
   ]
 
-  subnet_id = aws_subnet.default.id
+  subnet_id = "${element(aws_subnet.public.*.id, count.index)}"
 
   tags = {
     Name        = "dn-${terraform.workspace}-node-${count.index + 1}"
@@ -82,7 +82,7 @@ resource "aws_instance" "miner" {
     aws_security_group.dashd_private.id,
   ]
 
-  subnet_id = aws_subnet.default.id
+  subnet_id = "${element(aws_subnet.public.*.id, count.index)}"
 
   tags = {
     Name        = "dn-${terraform.workspace}-miner-${count.index + 1}"
@@ -105,7 +105,7 @@ resource "aws_instance" "masternode" {
     aws_security_group.masternode.id,
   ]
 
-  subnet_id = aws_subnet.default.id
+  subnet_id = "${element(aws_subnet.public.*.id, count.index)}"
 
   root_block_device {
     volume_size = "14"
@@ -125,7 +125,7 @@ resource "aws_instance" "vpn" {
   instance_type = "t3.nano"
   key_name      = aws_key_pair.auth.id
 
-  subnet_id = aws_subnet.default.id
+  subnet_id = "${element(aws_subnet.public.*.id, count.index)}"
 
   vpc_security_group_ids = [
     aws_security_group.vpn[0].id,

--- a/terraform/aws/security_groups.tf
+++ b/terraform/aws/security_groups.tf
@@ -22,10 +22,10 @@ resource "aws_security_group" "default" {
     protocol    = "tcp"
     description = "Docker API"
 
-    cidr_blocks = [
-      var.private_subnet,
+    cidr_blocks = flatten([
+      aws_subnet.public.*.cidr_block,
       "${aws_eip.vpn.public_ip}/32",
-    ]
+    ])
   }
 
   # outbound internet access
@@ -34,10 +34,10 @@ resource "aws_security_group" "default" {
     to_port   = 0
     protocol  = "-1"
 
-    cidr_blocks = [
+    cidr_blocks = flatten([
       "0.0.0.0/0",
-      var.private_subnet,
-    ]
+      aws_subnet.public.*.cidr_block,
+    ])
   }
 
   tags = {
@@ -59,9 +59,9 @@ resource "aws_security_group" "dashd_private" {
     protocol    = "tcp"
     description = "DashCore P2P"
 
-    cidr_blocks = [
-      var.private_subnet,
-    ]
+    cidr_blocks = flatten([
+      aws_subnet.public.*.cidr_block,
+    ])
   }
 
   # DashCore RPC access
@@ -71,10 +71,10 @@ resource "aws_security_group" "dashd_private" {
     protocol    = "tcp"
     description = "DashCore RPC"
 
-    cidr_blocks = [
-      var.private_subnet,
+    cidr_blocks = flatten([
+      aws_subnet.public.*.cidr_block,
       "${aws_eip.vpn.public_ip}/32",
-    ]
+    ])
   }
 
   # DashCore ZMQ acess
@@ -84,10 +84,10 @@ resource "aws_security_group" "dashd_private" {
     protocol    = "tcp"
     description = "DashCore ZMQ"
 
-    cidr_blocks = [
-      var.private_subnet,
+    cidr_blocks = flatten([
+      aws_subnet.public.*.cidr_block,
       "${aws_eip.vpn.public_ip}/32",
-    ]
+    ])
   }
 
   tags = {
@@ -121,10 +121,10 @@ resource "aws_security_group" "dashd_public" {
     protocol    = "tcp"
     description = "DashCore RPC"
 
-    cidr_blocks = [
-      var.private_subnet,
+    cidr_blocks = flatten([
+      aws_subnet.public.*.cidr_block,
       "${aws_eip.vpn.public_ip}/32",
-    ]
+    ])
   }
 
   # DashCore ZMQ acess
@@ -134,10 +134,10 @@ resource "aws_security_group" "dashd_public" {
     protocol    = "tcp"
     description = "DashCore ZMQ"
 
-    cidr_blocks = [
-      var.private_subnet,
+    cidr_blocks = flatten([
+      aws_subnet.public.*.cidr_block,
       "${aws_eip.vpn.public_ip}/32",
-    ]
+    ])
   }
 
   tags = {
@@ -157,10 +157,10 @@ resource "aws_security_group" "http" {
     protocol    = "tcp"
     description = "Faucet"
 
-    cidr_blocks = [
-      var.private_subnet,
+    cidr_blocks = flatten([
+      aws_subnet.public.*.cidr_block,
       "${aws_eip.vpn.public_ip}/32",
-    ]
+    ])
   }
 
   ingress {
@@ -169,10 +169,10 @@ resource "aws_security_group" "http" {
     protocol    = "tcp"
     description = "Insight Explorer"
 
-    cidr_blocks = [
-      var.private_subnet,
+    cidr_blocks = flatten([
+      aws_subnet.public.*.cidr_block,
       "${aws_eip.vpn.public_ip}/32",
-    ]
+    ])
   }
 
   tags = {
@@ -194,9 +194,9 @@ resource "aws_security_group" "masternode" {
     protocol    = "tcp"
     description = "IPFS swarm"
 
-    cidr_blocks = [
-      var.private_subnet,
-    ]
+    cidr_blocks = flatten([
+      aws_subnet.public.*.cidr_block,
+    ])
   }
 
   # IPFS API
@@ -206,10 +206,10 @@ resource "aws_security_group" "masternode" {
     protocol    = "tcp"
     description = "IPFS API"
 
-    cidr_blocks = [
-      var.private_subnet,
+    cidr_blocks = flatten([
+      aws_subnet.public.*.cidr_block,
       "${aws_eip.vpn.public_ip}/32",
-    ]
+    ])
   }
 
   # Insight API access
@@ -219,10 +219,10 @@ resource "aws_security_group" "masternode" {
     protocol    = "tcp"
     description = "Insight API"
 
-    cidr_blocks = [
-      var.private_subnet,
+    cidr_blocks = flatten([
+      aws_subnet.public.*.cidr_block,
       "${aws_eip.vpn.public_ip}/32",
-    ]
+    ])
   }
 
   # Drive
@@ -232,10 +232,10 @@ resource "aws_security_group" "masternode" {
     protocol    = "tcp"
     description = "Drive"
 
-    cidr_blocks = [
-      var.private_subnet,
+    cidr_blocks = flatten([
+      aws_subnet.public.*.cidr_block,
       "${aws_eip.vpn.public_ip}/32",
-    ]
+    ])
   }
 
   # DAPI
@@ -351,10 +351,10 @@ resource "aws_security_group" "vpn" {
     to_port   = 0
     protocol  = "-1"
 
-    cidr_blocks = [
+    cidr_blocks = flatten([
       "0.0.0.0/0",
-      var.private_subnet,
-    ]
+      aws_subnet.public.*.cidr_block,
+    ])
   }
 
   tags = {
@@ -362,4 +362,3 @@ resource "aws_security_group" "vpn" {
     DashNetwork = terraform.workspace
   }
 }
-

--- a/terraform/aws/variables.tf
+++ b/terraform/aws/variables.tf
@@ -64,9 +64,13 @@ variable "vpn_port" {
 variable "vpc_cidr" {
   default = "10.0.0.0/16"
 }
-
-variable "private_subnet" {
-  default = "10.0.0.0/16"
+variable "subnet_public_cidr" {
+  type = "list"
+  default = [
+    "10.0.16.0/20",
+    "10.0.32.0/20",
+    "10.0.48.0/20",
+  ]
 }
 
 variable "node_count" {


### PR DESCRIPTION
- adds a blacklist for AZs known to be not working
- renames the "private" subnets to public (they were always public because of
  the default route table association w/a route to the internet)
- adds a list variable for subnet CIDR ranges
- use the different subnets instead of locating all instances into one single
  AZ
