### PR TITLE
fix: network fork on restart

### DIFF
--- a/ansible/roles/mn-evo-services/tasks/tendermint.yml
+++ b/ansible/roles/mn-evo-services/tasks/tendermint.yml
@@ -25,6 +25,8 @@
     mode: 0750
 
 - name: create Tendermint configs
+  vars:
+    template_seeds: "{{ groups.seed_nodes | reject('equalto', inventory_hostname) }}"
   template:
     src: 'roles/mn-evo-services/templates/tendermint/{{ item }}.j2'
     dest: '{{ mn_evo_services_path }}/tendermint/config/{{ item }}'

--- a/ansible/roles/mn-evo-services/templates/tendermint/config.toml.j2
+++ b/ansible/roles/mn-evo-services/templates/tendermint/config.toml.j2
@@ -197,7 +197,7 @@ laddr = "tcp://0.0.0.0:26656"
 external_address = "{{ public_ip }}:26656"
 
 # Comma separated list of seed nodes to connect to
-seeds = "{% for seed in groups.seed_nodes %}{% if seed == inventory_hostname %}{% set temp = groups.seed_nodes.pop(loop.index0) %}{% endif %}{% endfor %}{% for seed in groups.seed_nodes %}{{ seed_nodes[seed].node_key.id }}@{{ hostvars[seed].public_ip }}:{{ tendermint_p2p_port }}{% if not loop.last %},{% endif %}{% endfor %}"
+seeds = "{% for seed in template_seeds %}{{ seed_nodes[seed].node_key.id }}@{{ hostvars[seed].public_ip }}:{{ tendermint_p2p_port }}{% if not loop.last %},{% endif %}{% endfor %}"
 
 # Comma separated list of nodes to keep persistent connections to
 persistent_peers = ""


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Testnet platform chain halted due to a disagreement about how to replay when syncing from scratch or after restarting in some cases. This was investigated and found to be due to the use of two seed nodes that do not have knowledge of each other.

## What was done?
<!--- Describe your changes in detail -->
Add seed node addresses to config for seed nodes.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Deployed on schnapps, stopped all nodes, restarted seed nodes one at a time, then restarted masternodes, network came back without any issues.

## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [x] I have assigned this pull request to a milestone
