### PR TITLE
fix: quorum hash value

### DIFF
--- a/ansible/roles/mn-evo-services/templates/tendermint/genesis.json.j2
+++ b/ansible/roles/mn-evo-services/templates/tendermint/genesis.json.j2
@@ -38,6 +38,6 @@
     "value": "imxjukh5hRY91Mvm/sfhQp6iSnICyvKMMdhY5Sq6Ej0QJyB3vtN4UfYwvmxdzOVM"
   },
   "quorum_type": {{ platform_drive_validator_set_llmq_type }},
-  "quorum_hash": "43FF39CC1F41B9FC63DFA5B1EDF3F0CA3AD5CAFAE4B12B4FE9263B08BB50C4CC",
+  "quorum_hash": "0000000000000000000000000000000000000000000000000000000000000000",
   "app_hash": ""
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Quorum hash should be set to hex 32 bytes null.

## What was done?
<!--- Describe your changes in detail -->
Update `quorum_hash` initial value in `genesis.json`. 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
On `devnet-jack-daniels`

## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->
None

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [x] I have assigned this pull request to a milestone
