### PR TITLE
chore: enable use_pregenerated_dh_params

### DIFF
--- a/ansible/roles/openvpn/tasks/main.yml
+++ b/ansible/roles/openvpn/tasks/main.yml
@@ -18,6 +18,7 @@
     openvpn_push: "{{ ['route-nopull'] + openvpn_forwarded_ips }}"
     openvpn_redirect_gateway: false
     openvpn_fetch_client_configs_dir: ~/tmp/ansible/
+    openvpn_use_pregenerated_dh_params: true
 
 - name: Copy OpenVPN config to 'networks' dir
   become: false


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
OpenVPN DH params were [generated by a role dependency](https://github.com/kyl191/ansible-role-openvpn/blob/master/tasks/server_keys.yml#L88-L105) fresh for each devnet, a process which takes around 4-5 minutes on each deployment. This is not necessary, params are not secret and the slight theoretical advantage they give an attacker is not relevant here because our devnets are low value targets.

## What was done?
<!--- Describe your changes in detail -->
Enable `openvpn_use_pregenerated_dh_params` setting

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
In a deployment

## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->
None

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone
