### PR TITLE
feat: individual MN debug toggle

### DIFF
--- a/ansible/roles/dashd/templates/dash.conf.j2
+++ b/ansible/roles/dashd/templates/dash.conf.j2
@@ -11,7 +11,12 @@ devnet={{ dash_devnet_name }}
 daemon=0  # leave this set to 0 for Docker
 logtimestamps=1
 maxconnections=256
+{% if masternode is defined %}
+debug={% if masternode.debug is defined or dashd_debug == 1 %}1{% else %}0{% endif %}
+{% else %}
 debug={{ dashd_debug }}
+{% endif %}
+
 printtoconsole=1
 
 {% if dashd_indexes %}

--- a/ansible/roles/dashd/templates/dash.conf.j2
+++ b/ansible/roles/dashd/templates/dash.conf.j2
@@ -11,11 +11,7 @@ devnet={{ dash_devnet_name }}
 daemon=0  # leave this set to 0 for Docker
 logtimestamps=1
 maxconnections=256
-{% if masternode is defined %}
 debug={% if masternode.debug is defined or dashd_debug == 1 %}1{% else %}0{% endif %}
-{% else %}
-debug={{ dashd_debug }}
-{% endif %}
 
 printtoconsole=1
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
Ody requested to be able to individually toggle MN debug logs so it is not all/nothing.

## What was done?
This solution looks for masternode.debug or the global dashd_debug variables. It uses defined for masternode.debug so previously generated configs will work just fine

Now we can simply add this sample code to MN's that need debug logs on:

`masternodes:
  masternode-1:
    owner:
      address: xx
      private_key: xx
    collateral:
      address: xx
      private_key: xx
    operator:
      public_key: >-
         xx
      private_key: xx
    node_key:
      id: xx
      private_key: >-
        xx
    **debug: 1**`

## How Has This Been Tested?
devnet


## Breaking Changes
None, backwards compatible AFAIK.
