### PR TITLE
fix: deploy fails silently if current branch not at HEAD

### DIFF
--- a/bin/deploy
+++ b/bin/deploy
@@ -53,7 +53,7 @@ done
 echo "Deploying $NETWORK_NAME network...";
 
 # TODO: this fails without an error if not at the HEAD of a given branch
-BRANCH=`git symbolic-ref --short -q HEAD`
+BRANCH=`git symbolic-ref --short HEAD`
 if [[ $BRANCH == "devnet-"* ]]; then
     if [[ $BRANCH != $NETWORK_NAME ]] && [[ $FORCED_DEPLOYMENT != 1 ]]; then
         echo "Wrong Devnet - Check you're in the correct branch. Use -f to force if you're sure"

--- a/bin/deploy
+++ b/bin/deploy
@@ -52,7 +52,7 @@ done
 
 echo "Deploying $NETWORK_NAME network...";
 
-# TODO: this fails without an error if not at the HEAD of a given branch
+# TODO: this fails if not at the HEAD of a given branch
 BRANCH=`git symbolic-ref --short HEAD`
 if [[ $BRANCH == "devnet-"* ]]; then
     if [[ $BRANCH != $NETWORK_NAME ]] && [[ $FORCED_DEPLOYMENT != 1 ]]; then


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
`bin/deploy` would fail with exit code 1 and no visible error if deploying from a commit below HEAD on any given branch

## What was done?
<!--- Describe your changes in detail -->
Remove `-q` so the failing command displays an error, thusly:
```
Deploying devnet-jack-daniels network...
fatal: ref HEAD is not a symbolic ref
```

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Locally

## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone
