### PR TITLE
chore: use module instead of command to list docker containers

### DIFF
--- a/ansible/roles/elastic_beats/tasks/main.yml
+++ b/ansible/roles/elastic_beats/tasks/main.yml
@@ -1,14 +1,18 @@
 ---
 
 - name: Get core container id
-  ansible.builtin.command: docker ps -aqf "name=dashd"
-  register: core_container_id
-  changed_when: core_container_id.stdout | length > 0
+  community.docker.docker_host_info:
+    containers: true
+    containers_filters:
+      name: dashd
+  register: core_host_info
 
 - name: Get tenderdash container id
-  ansible.builtin.command: docker ps -aqf "name=mn_evo_services_tendermint"
-  register: tenderdash_container_id
-  changed_when: tenderdash_container_id.stdout | length > 0
+  community.docker.docker_host_info:
+    containers: true
+    containers_filters:
+      name: mn_evo_services_tendermint
+  register: tenderdash_host_info
 
 - name: Load common filebeat config
   ansible.builtin.include_vars:
@@ -21,12 +25,12 @@
 - name: Load platform input config
   ansible.builtin.include_vars:
     file: platform.yml
-  when: tenderdash_container_id.stdout != ""
+  when: tenderdash_host_info.containers | length > 0
 
 - name: Merge input configs
   ansible.builtin.set_fact:
     filebeat_inputs: "{{ [filebeat_inputs, filebeat_platform_inputs] | community.general.lists_mergeby('index') }}"
-  when: tenderdash_container_id.stdout != ""
+  when: tenderdash_host_info.containers | length > 0
 
 - name: Set up filebeat log monitoring
   ansible.builtin.include_role:

--- a/ansible/roles/elastic_beats/vars/core.yml
+++ b/ansible/roles/elastic_beats/vars/core.yml
@@ -5,7 +5,7 @@ filebeat_inputs:
     enabled: true
     index: "logs-core-{{ dash_network_name }}-%{[agent.version]}"
     paths:
-      - '/var/lib/docker/containers/{{ core_host_info.containers[0].Id }}*/*.log'
+      - '/var/lib/docker/containers/{{ core_host_info.containers[0].Id }}/*.log'
     processors:
       - add_fields:
           target: event

--- a/ansible/roles/elastic_beats/vars/core.yml
+++ b/ansible/roles/elastic_beats/vars/core.yml
@@ -5,7 +5,7 @@ filebeat_inputs:
     enabled: true
     index: "logs-core-{{ dash_network_name }}-%{[agent.version]}"
     paths:
-      - '/var/lib/docker/containers/{{ core_container_id.stdout }}*/*.log'
+      - '/var/lib/docker/containers/{{ core_host_info.containers[0].Id }}*/*.log'
     processors:
       - add_fields:
           target: event

--- a/ansible/roles/elastic_beats/vars/platform.yml
+++ b/ansible/roles/elastic_beats/vars/platform.yml
@@ -2,7 +2,7 @@
 
 filebeat_platform_inputs:
   - type: log
-    enabled: "{{ tenderdash_container_id.stdout | length > 0 }}"
+    enabled: "{{ tenderdash_host_info.containers | length > 0 }}"
     json.message_key: msg
     json.keys_under_root: false
     exclude_files: ['\.gz$']
@@ -79,12 +79,12 @@ filebeat_platform_inputs:
             - json.time
           ignore_missing: true
   - type: container
-    enabled: "{{ tenderdash_container_id.stdout | length > 0 }}"
+    enabled: "{{ tenderdash_host_info.containers | length > 0 }}"
     json.message_key: _msg
     json.keys_under_root: false
     index: "logs-drive.tenderdash-{{ dash_network_name }}-%{[agent.version]}"
     paths:
-      - '/var/lib/docker/containers/{{ tenderdash_container_id.stdout }}*/*.log'
+      - '/var/lib/docker/containers/{{ tenderdash_host_info.containers[0].Id }}*/*.log'
     processors:
       - add_fields:
           target: event

--- a/ansible/roles/elastic_beats/vars/platform.yml
+++ b/ansible/roles/elastic_beats/vars/platform.yml
@@ -84,7 +84,7 @@ filebeat_platform_inputs:
     json.keys_under_root: false
     index: "logs-drive.tenderdash-{{ dash_network_name }}-%{[agent.version]}"
     paths:
-      - '/var/lib/docker/containers/{{ tenderdash_host_info.containers[0].Id }}*/*.log'
+      - '/var/lib/docker/containers/{{ tenderdash_host_info.containers[0].Id }}/*.log'
     processors:
       - add_fields:
           target: event


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
`elastic_beats` was collecting container IDs through a shell command rather than an ansible module.

## What was done?
<!--- Describe your changes in detail -->
Switch to using ansible module

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
On custom devnet

## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->
None

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [x] I have assigned this pull request to a milestone
