### PR TITLE
fix: double platform service startup

### DIFF
--- a/ansible/roles/mn_evo_services/tasks/main.yml
+++ b/ansible/roles/mn_evo_services/tasks/main.yml
@@ -58,11 +58,6 @@
     - .env
     - dapi-envoy.yaml
 
-- name: Pull platform docker images
-  community.docker.docker_compose:
-    project_src: '{{ mn_evo_services_path }}'
-    pull: true
-
 - name: Configure Tendermint
   ansible.builtin.import_tasks: tendermint.yml
   vars:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This command was refactored to use the `docker_compose` module, which had the unintentional side effect of starting the services as well as pulling them. Since we no need to run `tenderdash init` before starting tenderdash, we no longer need to pull the images before starting the services, which happens at the end of this role.

## What was done?
<!--- Describe your changes in detail -->
Remove explicit pull command when setting up platform

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
On devnet-jack-daniels

## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->
None

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [x] I have assigned this pull request to a milestone
