### PR TITLE
Zabbix monitoring for devnets

### DIFF
--- a/ansible/deploy.yml
+++ b/ansible/deploy.yml
@@ -68,6 +68,13 @@
       aws_scripts_mon_options: "--mem-util --disk-space-util --disk-path=/ --swap-util"
       aws_scripts_mon_use_iam: true
 
+- name: Install Zabbix monitoring on masternodes
+  hosts: masternodes
+  become: true
+  roles:
+    - role: zabbix
+      when: zabbix == 1
+
 # Install Dash Core
 
 - name: Configure dashd cli and network logging

--- a/ansible/roles/zabbix/files/docker-compose.yml
+++ b/ansible/roles/zabbix/files/docker-compose.yml
@@ -1,0 +1,15 @@
+version: '3.1'
+
+services:
+  zabbix-agent:
+    container_name: zabbix-agent
+    image: zabbix/zabbix-agent
+    user: root
+    restart: always
+    privileged: true
+    volumes:
+      - /var/run:/var/run
+    ports:
+      - '10050:10050'
+    environment:
+      - ZBX_SERVER_HOST=zabbix.dash.org

--- a/ansible/roles/zabbix/files/overrides.conf.j2
+++ b/ansible/roles/zabbix/files/overrides.conf.j2
@@ -1,0 +1,7 @@
+Server=zabbix.dash.org
+ServerActive=zabbix.dash.org
+
+TLSConnect=psk
+TLSAccept=psk
+TLSPSKFile=/etc/zabbix/zabbix.psk
+TLSPSKIdentity=PSK001

--- a/ansible/roles/zabbix/files/zabbix.psk
+++ b/ansible/roles/zabbix/files/zabbix.psk
@@ -1,0 +1,1 @@
+{{ zabbix_psk_key }}

--- a/ansible/roles/zabbix/tasks/docker.yml
+++ b/ansible/roles/zabbix/tasks/docker.yml
@@ -1,0 +1,21 @@
+---
+
+- name: Create a directory if it does not exist
+  file:
+    path: /dash/zabbix/
+    state: directory
+    mode: '0755'
+
+- name: Add compose file
+  copy:
+    src: "{{ item }}"
+    dest: "/dash/zabbix/{{ item }}"
+  with_items:
+    - docker-compose.yml
+
+- name: Start zabbix
+  docker_compose:
+    project_src: '/dash/zabbix/'
+    state: present
+    restarted: yes
+    pull: yes

--- a/ansible/roles/zabbix/tasks/main.yml
+++ b/ansible/roles/zabbix/tasks/main.yml
@@ -1,0 +1,19 @@
+---
+# file: zabbix/tasks/main.yml
+
+#Check if docker installed
+
+- name: Check if Docker is installed
+  command: docker-compose --version
+  register: docker_valid
+  ignore_errors: yes
+
+#Zabbix install w/o Docker
+
+- name: Zabbix install if docker-compose is not on host
+  import_tasks: non-docker.yml
+  when: docker_valid is failed
+
+- name: Zabbix install via docker-compose
+  import_tasks: docker.yml
+  when: docker_valid is succeeded

--- a/ansible/roles/zabbix/tasks/non-docker.yml
+++ b/ansible/roles/zabbix/tasks/non-docker.yml
@@ -1,0 +1,29 @@
+---
+
+- name: Install zabbix agent
+  apt:
+    name:
+      - zabbix-agent
+    state: present
+    update_cache: yes
+    cache_valid_time: 3600
+
+- name: Add zabbix key
+  copy:
+    src: "{{ item }}"
+    dest: "/etc/zabbix/{{ item }}"
+  with_items:
+    - zabbix.psk
+
+- name: Install zabbix overrides
+  copy:
+    src: "{{ item }}.j2"
+    dest: "/etc/zabbix/zabbix_agentd.conf.d/{{ item }}"
+  with_items:
+    - overrides.conf
+
+- name: Restart zabbix agent
+  systemd:
+    state: restarted
+    daemon_reload: yes
+    name: zabbix-agent

--- a/terraform/aws/security_groups.tf
+++ b/terraform/aws/security_groups.tf
@@ -332,6 +332,18 @@ resource "aws_security_group" "masternode" {
     ])
   }
 
+  # Zabbix
+  ingress {
+    from_port   = var.zabbix_port
+    to_port     = var.zabbix_port
+    protocol    = "tcp"
+    description = "Zabbix"
+
+    cidr_blocks = [
+      "128.199.172.189/32",
+    ]
+  }
+
   tags = {
     Name        = "dn-${terraform.workspace}-masternode"
     DashNetwork = terraform.workspace

--- a/terraform/aws/variables.tf
+++ b/terraform/aws/variables.tf
@@ -179,3 +179,8 @@ variable "wallet_node_instance_size" {
   description = "Instance type of wallet nodes"
   default     = "micro"
 }
+
+variable "zabbix_port" {
+  description = "Zabbix port"
+  default     = 10050
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
Zabbix monitoring can now be enabled on devnets

## What was done?
Zabbix security group rule has been added in terraform to allow 10050
Zabbix agent installation done via an Ansible role


## How Has This Been Tested?
Tested on devnet-ouzo


## Breaking Changes
None, zabbix will only install if zabbix=1 is in the config