### PR TITLE
chore: role should leave faucet in updated state

### DIFF
--- a/ansible/roles/multifaucet/tasks/main.yml
+++ b/ansible/roles/multifaucet/tasks/main.yml
@@ -32,6 +32,7 @@
     project_src: '{{ dashd_home }}/multifaucet'
     state: present
     build: true
+    pull: true
 
 - name: Wait for database to be available
   community.docker.docker_container_exec:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Most networks use `dashpay/multifaucet:latest` as the default faucet image. Since this tag can point to different images over time, the role must pull the image to leave the target in the desired updated state. To override this, specify a semver tag instead.

## What was done?
<!--- Describe your changes in detail -->
Update faucet image if necessary when running multifaucet role.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
On testnet

## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->
None

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone
