### PR TITLE
chore: fix loadwallet and handle misconfigured masternodes

### DIFF
--- a/ansible/roles/dashd/tasks/main.yml
+++ b/ansible/roles/dashd/tasks/main.yml
@@ -82,11 +82,12 @@
     mode: "+x"
 
 - name: Load/create faucet wallet on startup
-  ansible.builtin.lineinfile:
+  ansible.builtin.blockinfile:
     path: '/etc/dash.conf'
-    regexp: '^wallet='
-    line: wallet={{ wallet_rpc_wallet_faucet }}
     insertafter: '[{{ dash_network }}]'
+    block: |
+      wallet={{ wallet_rpc_wallet_faucet }}
+      wallet={{ wallet_rpc_wallet_mno }}
   when: enable_wallet is true
 
 # TODO: why does this always take exactly 30 seconds on first deploy?
@@ -111,9 +112,3 @@
   register: result
   when: enable_wallet is true
   changed_when: result.rc == 0
-
-- name: Create mno wallet
-  ansible.builtin.command: 'dash-cli createwallet {{ wallet_rpc_wallet_mno }}'
-  when: enable_wallet is true
-  args:
-    creates: "{{ dashd_home }}/.dashcore/{{ dash_network_name if dash_network == 'devnet' else 'testnet3' }}/wallets/{{ wallet_rpc_wallet_mno }}/wallet.dat"

--- a/ansible/roles/mn_createprotx/tasks/createprovidertx.yml
+++ b/ansible/roles/mn_createprotx/tasks/createprovidertx.yml
@@ -4,11 +4,11 @@
 
 - name: Verify fee balance is ready to spend
   ansible.builtin.command: >
-    dash-cli getaddressbalance '{"addresses": ["{{ fee_address.stdout }}"]}'
+    dash-cli getaddressbalance '{"addresses": ["{{ masternode.collateral.address }}"]}'
   retries: 10
   delay: 1
   register: result
-  until: result.stdout | from_json | json_query('balance_spendable') | int >= 100000000
+  until: result.stdout | from_json | json_query('balance_spendable') | int > 100000000000
   changed_when: result.stdout | length > 0
 
 - name: Create ProTx for {{ masternode_name ~ '/' ~ masternode.owner.address }}
@@ -21,6 +21,6 @@
             {{ masternode.owner.address }}
             0
             {{ miner_payment_address }}
-            {{ fee_address.stdout }}"
+            {{ masternode.collateral.address }}"
   register: protx
   changed_when: protx.stdout | length == 64

--- a/ansible/roles/mn_createprotx/tasks/main.yml
+++ b/ansible/roles/mn_createprotx/tasks/main.yml
@@ -1,37 +1,5 @@
 ---
 
-# Requires "masternode_names" variable
-
-- name: Import masternode owner private key
-  ansible.builtin.command: 'dash-cli -rpcwallet={{ wallet_rpc_wallet_mno }} importprivkey {{ masternodes[item].owner.private_key }} "" false'
-  with_items: '{{ masternode_names }}'
-  register: result
-  changed_when: result.rc == 0
-
-- name: Rescan blockchain
-  ansible.builtin.command: 'dash-cli -rpcwallet={{ wallet_rpc_wallet_mno }} rescanblockchain'
-  register: result
-  changed_when: result.stdout | to_json | json_query('stop_height') | int > 1
-
-# fund fee
-
-- name: Get new fee address
-  ansible.builtin.command: 'dash-cli -rpcwallet={{ wallet_rpc_wallet_mno }} getnewaddress'
-  register: fee_address
-  changed_when: fee_address.stdout | length == 34
-
-- name: Fund fee address
-  ansible.builtin.command: 'dash-cli -rpcwallet={{ wallet_rpc_wallet_faucet }} sendtoaddress {{ fee_address.stdout }} 10'
-  register: fund_result
-  changed_when: fund_result.stdout | length == 64
-
-- name: Generate at least one block to confirm fee funding transaction
-  ansible.builtin.include_role:
-    name: generate_blocks
-  vars:
-    num_blocks: 1
-    balance_needed: 0
-
 # register
 
 - name: Create provider registration transaction

--- a/ansible/roles/mn_init/tasks/main.yml
+++ b/ansible/roles/mn_init/tasks/main.yml
@@ -129,7 +129,7 @@
 - name: Populate fee payment targets
   ansible.builtin.set_fact:
     fee_target_addresses: "{{ fee_target_addresses | default([]) + [masternodes[item].collateral.address] }}"
-  with_items: '{{ groups["masternodes"] }}'    
+  with_items: '{{ groups["masternodes"] }}'
 
 - name: Check if address contains a suitable fee utxo
   ansible.builtin.command: >

--- a/ansible/roles/mn_init/tasks/main.yml
+++ b/ansible/roles/mn_init/tasks/main.yml
@@ -57,6 +57,8 @@
   register: get_protx_list_result
   changed_when: get_protx_list_result.stdout | to_json | length > 0
 
+# Registered masternodes list
+
 - name: Initialize array for registered masternode names
   ansible.builtin.set_fact:
     registered_masternode_names: []
@@ -71,6 +73,8 @@
   ansible.builtin.debug:
     var: registered_masternode_names
 
+# New masternodes list
+
 - name: Determine new masternodes
   ansible.builtin.set_fact:
     new_masternode_names: "{{ groups['masternodes'] | difference(registered_masternode_names) }}"
@@ -78,6 +82,8 @@
 - name: New masternodes list
   ansible.builtin.debug:
     var: new_masternode_names
+
+# Banned masternodes list
 
 - name: Get list of banned masternodes from the wallet
   ansible.builtin.set_fact:
@@ -151,6 +157,9 @@
   vars:
     num_blocks: 1
     balance_needed: 0
+
+# Take action
+
 - name: Fund collaterals for not initialized masternodes
   ansible.builtin.include_role:
     name: mn_fund_collateral

--- a/ansible/roles/mn_init/tasks/main.yml
+++ b/ansible/roles/mn_init/tasks/main.yml
@@ -89,6 +89,39 @@
   ansible.builtin.debug:
     var: banned_masternode_names
 
+# Fund fee
+
+- name: Populate fee payment targets
+  ansible.builtin.set_fact:
+    fee_target_addresses: "{{ fee_target_addresses | default([]) + [masternodes[item].collateral.address] }}"
+  with_items: '{{ groups["masternodes"] }}'    
+
+- name: Check if address contains a suitable fee utxo
+  ansible.builtin.command: >
+    dash-cli -rpcwallet={{ wallet_rpc_wallet_mno }} listunspent 1 99999999 '{{ fee_target_addresses | to_json }}' false '{{ maxamount | to_json }}'
+  register: funded_addresses
+  changed_when: funded_addresses.stdout | from_json | length > 0
+  vars:
+    maxamount:
+      maximumAmount: 1
+
+- name: Figure out which addresses need fee funding
+  ansible.builtin.set_fact:
+    fee_missing_addresses: "{{ fee_target_addresses | difference(funded_addresses.stdout) }}"
+
+- name: Fund 1 coin for ProTx fee
+  ansible.builtin.include_tasks: ./roles/mn_fund_collateral/tasks/fund_collateral.yml
+  vars:
+    amount: 1
+    payment_targets: '{{ fee_target_addresses }}'
+  when: fee_target_addresses|length > 0
+
+- name: Generate at least one block to confirm fee funding transactions
+  ansible.builtin.include_role:
+    name: generate_blocks
+  vars:
+    num_blocks: 1
+    balance_needed: 0
 - name: Fund collaterals for not initialized masternodes
   ansible.builtin.include_role:
     name: mn_fund_collateral

--- a/ansible/roles/mn_init/tasks/main.yml
+++ b/ansible/roles/mn_init/tasks/main.yml
@@ -1,15 +1,6 @@
 ---
 
-- name: List loaded wallets
-  ansible.builtin.command: 'dash-cli listwallets'
-  register: loaded_wallets
-  changed_when: loaded_wallets.rc == 0
-
-- name: Load mno wallet
-  ansible.builtin.command: 'dash-cli loadwallet {{ wallet_rpc_wallet_mno }}'
-  when: wallet_rpc_wallet_mno not in loaded_wallets.stdout
-  register: load_wallet
-  changed_when: load_wallet.rc == 0
+# Init
 
 - name: Wait for wallet sync
   register: blockchain_status
@@ -43,6 +34,23 @@
   delay: 60
   until: mnsync_status.stdout | from_json | json_query('IsSynced') == true
   changed_when: mnsync_status.stdout | from_json | json_query('IsSynced') == true
+
+- name: Import masternode owner private key
+  ansible.builtin.command: 'dash-cli -rpcwallet={{ wallet_rpc_wallet_mno }} importprivkey {{ masternodes[item].owner.private_key }} "" false'
+  with_items: '{{ groups["masternodes"] }}'
+  register: result
+  changed_when: result.rc == 0
+
+- name: Import masternode collateral private keys
+  ansible.builtin.command: 'dash-cli -rpcwallet={{ wallet_rpc_wallet_mno }} importprivkey {{ masternodes[item].collateral.private_key }} "" false'
+  with_items: '{{ groups["masternodes"] }}'
+  register: result
+  changed_when: result.rc == 0
+
+- name: Rescan blockchain
+  ansible.builtin.command: 'dash-cli -rpcwallet={{ wallet_rpc_wallet_mno }} rescanblockchain'
+  register: result
+  changed_when: result.stdout | to_json | json_query('stop_height') | int > 1
 
 - name: Get list of ProTx transactions from the wallet
   ansible.builtin.command: dash-cli -rpcwallet={{ wallet_rpc_wallet_mno }} protx list wallet true

--- a/ansible/roles/mn_init/tasks/main.yml
+++ b/ansible/roles/mn_init/tasks/main.yml
@@ -89,6 +89,27 @@
   ansible.builtin.debug:
     var: banned_masternode_names
 
+# Misconfigured masternode list
+
+- name: Initialize array for misconfigured masternode names
+  ansible.builtin.set_fact:
+    misconfigured_masternode_names: []
+
+- name: Get names of misconfigured masternodes
+  ansible.builtin.set_fact:
+    misconfigured_masternode_names: '{{ misconfigured_masternode_names + [item] }}'
+  when: >
+    get_protx_list_result.stdout | from_json |
+    json_query("[?state.ownerAddress=='" + masternodes[item].owner.address + "']") |
+    json_query("[?state.service!='" + hostvars[item].public_ip + ":" + dashd_port | string  + "']")
+  with_items: '{{ registered_masternode_names }}'
+
+# We should probably subtract the banned masternodes from this list so we don't unban twice
+# or just merge the list with banned masternodes and run proupsrv once for both lists
+- name: Misconfigured masternodes list
+  ansible.builtin.debug:
+    var: misconfigured_masternode_names
+
 # Fund fee
 
 - name: Populate fee payment targets
@@ -143,7 +164,9 @@
     masternode_names: '{{ banned_masternode_names }}'
   when: banned_masternode_names | length > 0
 
-- name: Unload mno wallet
-  ansible.builtin.command: 'dash-cli unloadwallet {{ wallet_rpc_wallet_mno }}'
-  register: unload_wallet
-  changed_when: unload_wallet.rc == 0
+- name: Update service for misconfigured masternodes
+  ansible.builtin.include_role:
+    name: mn_unban
+  vars:
+    masternode_names: '{{ misconfigured_masternode_names }}'
+  when: misconfigured_masternode_names | length > 0

--- a/ansible/roles/mn_protx_config/tasks/main.yml
+++ b/ansible/roles/mn_protx_config/tasks/main.yml
@@ -1,16 +1,5 @@
 ---
 
-- name: List loaded wallets
-  ansible.builtin.command: 'dash-cli listwallets'
-  register: loaded_wallets
-  changed_when: loaded_wallets.rc == 0
-
-- name: Load mno wallet
-  ansible.builtin.command: 'dash-cli loadwallet {{ wallet_rpc_wallet_mno }}'
-  when: wallet_rpc_wallet_mno not in loaded_wallets.stdout
-  register: load_wallet
-  changed_when: load_wallet.rc == 0
-
 - name: Get list of ProTx transactions from the wallet
   ansible.builtin.command: dash-cli -rpcwallet={{ wallet_rpc_wallet_mno }} protx list wallet true
   register: get_protx_list_result
@@ -45,8 +34,3 @@
     line: '\1 protx={{ item.protx }}'
     backrefs: true
   with_items: '{{ registered_masternode_protx }}'
-
-- name: Unload mno wallet
-  ansible.builtin.command: 'dash-cli unloadwallet {{ wallet_rpc_wallet_mno }}'
-  register: unload_wallet
-  changed_when: unload_wallet.rc == 0

--- a/ansible/roles/mn_unban/tasks/createproupservtx.yml
+++ b/ansible/roles/mn_unban/tasks/createproupservtx.yml
@@ -8,6 +8,6 @@
             {{ hostvars[masternode_name].public_ip }}:{{ dashd_port }}
             {{ masternode.operator.private_key }}
             ''
-            {{ fee_address.stdout }}" # Should already be funded from registration protx
+            {{ masternode.collateral.address }}" # Should already be funded from registration protx
   register: protx
   changed_when: protx.stdout | length == 64

--- a/ansible/roles/mn_unban/tasks/main.yml
+++ b/ansible/roles/mn_unban/tasks/main.yml
@@ -2,7 +2,7 @@
 
 # Requires "masternodes" and "masternode_names" variables
 
-- name: Get list of banned masternode protx
+- name: Get list of masternode protx
   ansible.builtin.include_tasks: find_protx.yml
   vars:
     masternode: '{{ masternodes[item] }}'


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Supersedes #405 and #406 
#390 introduced use of the `loadwallet` command, which fails to lock masternode outputs present in the wallet on load. Deploy tool depends on these outputs being locked, so the issue results in masternode collaterals being consumed as fees in other transactions. This issue was handled with static fee addresses in #400, which introduced a new limitation on how many transactions the deploy tool could create without needing to wait for a block. We need to revert code from these two PRs and load both wallets on startup to ensure outputs are locked.


## What was done?
<!--- Describe your changes in detail -->
Revert #400 
Partially revert #390 
Introduce handling for misconfigured masternodes (ENABLED but with wrong service address, and cannot be banned because all nodes have wrong service address)

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
On `testnet` and `devnet-bintang`

## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->
None

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone
