### PR TITLE
fix: elasticsearch cluster status yellow due to missing replicas

### DIFF
--- a/ansible/roles/elastic_stack/tasks/configure_cluster.yml
+++ b/ansible/roles/elastic_stack/tasks/configure_cluster.yml
@@ -10,6 +10,18 @@
     body_format: json
     body: "{{ lookup('file', 'files/ilm_policy.json') }}"
 
+- name: Set replica count to zero
+  when: play_hosts | length == 1
+  ansible.builtin.uri:
+    url: http://localhost:9200/_settings
+    method: PUT
+    status_code: 200
+    user: '{{ elastic_username }}'
+    password: '{{ elastic_password }}'
+    body_format: json
+    body:
+      number_of_replicas: 0
+
 - name: Set up core index template
   ansible.builtin.uri:
     url: http://localhost:9200/_index_template/logs-core


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
The Elasticsearch `/_cluster/health` endpoint was returning `yellow` status due to missing replicas, even on networks where only a single logging node is present and replicas are therefore not possible. This was causing smoke tests to fail and turn red. We don't like yellow or red; green is our favourite colour.

## What was done?
<!--- Describe your changes in detail -->
Set `number_of_replicas: 0` if logging cluster size is 1.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
On `devnet-bintang`

## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->
None

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [x] I have assigned this pull request to a milestone
