### PR TITLE
fix: uacomment spacing

### DIFF
--- a/ansible/roles/dashd/templates/dash.conf.j2
+++ b/ansible/roles/dashd/templates/dash.conf.j2
@@ -12,6 +12,7 @@ daemon=0  # leave this set to 0 for Docker
 logtimestamps=1
 maxconnections=256
 debug={% if masternode.debug is defined or dashd_debug == 1 %}1{% else %}0{% endif %}
+
 uacomment=dcg-{{ inventory_hostname }}
 
 printtoconsole=1


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
A newline character was missing after templating, resulting in `debug=1uacomment=dcg-masternode-1`

## What was done?
<!--- Describe your changes in detail -->
Jinja has changed rules around newline whitespacing recently. Easiest fix is to add a hard, untemplated newline to ensure it works on all versions.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
On testnet

## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->
None

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [x] I have assigned this pull request to a milestone
