### PR TITLE
fix: Restart docker with systemd

### DIFF
--- a/ansible/roles/docker_options/handlers/main.yml
+++ b/ansible/roles/docker_options/handlers/main.yml
@@ -1,7 +1,7 @@
 ---
 
 - name: Restart docker
-  ansible.builtin.service:
+  ansible.builtin.systemd:
     name: docker
     state: restarted
     daemon_reload: true


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
Small fix for using systemd instead of service so daemon_reload is recognised. This is to satisfy a Github Actions check

## What was done?
Use ansible builtin systemd instead of service


## How Has This Been Tested?
Via GH actions 


## Breaking Changes
None
