### PR TITLE
fix: confusing division and type casting

### DIFF
--- a/ansible/deploy.yml
+++ b/ansible/deploy.yml
@@ -203,7 +203,7 @@
   roles:
     - role: mn_init
       mnlist: "{{ masternodes }}"
-      register: 'mn'
+      funding_amount: "{{ masternode_collaterals.mn | int }}"
 
 - name: Update inventory with protx values
   hosts: wallet_nodes
@@ -217,7 +217,7 @@
   roles:
     - role: mn_init
       mnlist: "{{ hp_masternodes }}"
-      register: 'hpmn'
+      funding_amount: "{{ masternode_collaterals.hpmn | int }}"
 
 - name: Update inventory with HPMN protx values
   hosts: wallet_nodes

--- a/ansible/group_vars/all
+++ b/ansible/group_vars/all
@@ -141,8 +141,8 @@ masternode_wallet_rpc_password: "{{ dashd_rpc_password }}"
 masternode_wallet_rpc_args: "-rpcconnect={{ masternode_wallet_rpc_host }} -rpcport={{ masternode_wallet_rpc_port }} -rpcuser={{ masternode_wallet_rpc_user }} -rpcpassword={{ masternode_wallet_rpc_password }}"
 
 masternode_collaterals:
-  mn: 100000000
-  hpmn: 400000000
+  mn: 1000
+  hpmn: 4000
 
 # Disk space allocated for swap file on each host
 swap_space: 2G

--- a/ansible/roles/mn_find_collateral/scripts/find-collateral.py
+++ b/ansible/roles/mn_find_collateral/scripts/find-collateral.py
@@ -6,7 +6,7 @@ import json
 
 rpcargs = sys.argv[1]
 mn_address = sys.argv[2]
-coin = sys.argv[3]
+coin = int(sys.argv[3]) * 100000
 find_protx = sys.argv[4] == 'True'
 
 blockchaininfo_s = subprocess.run("dash-cli %s getblockchaininfo" % (rpcargs), shell=True, check=True, stdout=subprocess.PIPE).stdout.decode("utf-8")
@@ -33,7 +33,7 @@ utxos = unspent
 for u in addressutxos:
     e = {
         "txid": u.get('txid'),
-        "amount": u.get('satoshis') / int(coin),
+        "amount": u.get('satoshis') / coin,
         "vout": u.get('outputIndex'),
         "confirmations": tipHeight - u.get('height')
     }

--- a/ansible/roles/mn_fund_collateral/tasks/fund_collateral.yml
+++ b/ansible/roles/mn_fund_collateral/tasks/fund_collateral.yml
@@ -16,7 +16,7 @@
   ansible.builtin.debug:
     var: payments
 
-- name: Fund listed masternodes with {{ amount }}
+- name: Fund listed masternodes with {{ amount ~ ' Dash'}}
   ansible.builtin.command: "dash-cli -rpcwallet={{ wallet_rpc_wallet_faucet }} sendmany '' '{{ payments | to_json }}'"
   register: fund_result
   changed_when: fund_result.stdout | length == 64

--- a/ansible/roles/mn_fund_collateral/tasks/main.yml
+++ b/ansible/roles/mn_fund_collateral/tasks/main.yml
@@ -36,7 +36,7 @@
     name: generate_blocks
   vars:
     generate: balance
-    target_balance: "{{ (masternode_names | length - collateral_ok_count | int) * (funding_amount | int / 100000) | int }}"
+    target_balance: "{{ (masternode_names | length - collateral_ok_count | int) * funding_amount | int }}"
   when: not collateral_all_ok and (faucet_balance.stdout | int < target_balance | int)
 
 # TODO: this will fund all masternodes when `not collateral_all_ok`, not just those with missing collateral.
@@ -60,7 +60,7 @@
   ansible.builtin.include_tasks:
     file: fund_collateral.yml
   vars:
-    amount: "{{ (funding_amount | int / 100000) | int }}"
+    amount: "{{ funding_amount }}"
     payment_targets: '{{ uncollateralized_addresses }}'
   when: not collateral_all_ok
 

--- a/ansible/roles/mn_init/tasks/main.yml
+++ b/ansible/roles/mn_init/tasks/main.yml
@@ -159,11 +159,6 @@
     payment_targets: '{{ fee_missing_addresses }}'
   when: fee_missing_addresses | length > 0
 
-# Isn't there some nicer way to do this with a map?
-- name: Set funding amount
-  ansible.builtin.set_fact:
-    funding_amount: "{% if register == 'hpmn' %}{{ masternode_collaterals.hpmn }}{% else %}{{ masternode_collaterals.mn }}{% endif %}"
-
 # Take action
 
 - name: Fund collaterals for not initialized masternodes

--- a/ansible/roles/mn_init/tasks/main.yml
+++ b/ansible/roles/mn_init/tasks/main.yml
@@ -162,12 +162,7 @@
 # Isn't there some nicer way to do this with a map?
 - name: Set funding amount
   ansible.builtin.set_fact:
-    funding_amount: |
-      {% if register == 'hpmn' %}
-        {{ masternode_collaterals.hpmn | int }}
-      {% else %}
-        {{ masternode_collaterals.mn | int }}
-      {% endif %}
+    funding_amount: "{% if register == 'hpmn' %}{{ masternode_collaterals.hpmn }}{% else %}{{ masternode_collaterals.mn }}{% endif %}"
 
 # Take action
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Most apps deal with dash not duffs and dividing duff amounts in Python causes type casting problems. Jinja2 templating always returns a string, which makes further handling of output from the conditional logic extremely annoying.

## What was done?
<!--- Describe your changes in detail -->
Remove jinja2 template and simplify logic, replace division with multiplication

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
On `devnet-xxxx`

## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->
None

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [x] I have assigned this pull request to a milestone
