### PR TITLE
fix: all mns are funded collateral if only one is not ok

### DIFF
--- a/ansible/roles/mn_fund_collateral/tasks/main.yml
+++ b/ansible/roles/mn_fund_collateral/tasks/main.yml
@@ -39,9 +39,7 @@
     target_balance: "{{ (masternode_names | length - collateral_ok_count | int) * funding_amount | int }}"
   when: not collateral_all_ok and (faucet_balance.stdout | int < target_balance | int)
 
-# TODO: this will fund all masternodes when `not collateral_all_ok`, not just those with missing collateral.
-# collateral_ok_masternode_1 was partially implemented, check again later
-# https://github.com/dashpay/dash-network-deploy/blob/master/ansible/roles/mn-fund-collateral/tasks/main.yml#L48
+# fund
 
 - name: Initialize array for uncollateralized addresses
   ansible.builtin.set_fact:
@@ -50,11 +48,8 @@
 - name: Populate payment targets
   ansible.builtin.set_fact:
     uncollateralized_addresses: "{{ uncollateralized_addresses + [mnlist[item].collateral.address] }}"
-  with_items:
-    - '{{ masternode_names }}'
-  when: not collateral_all_ok
-
-# fund
+  with_items: '{{ masternode_names }}'
+  when: not vars["collateral_ok_" + item|replace("-","_")]
 
 - name: Fund masternode collaterals
   ansible.builtin.include_tasks:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
All masternodes (not just those with missing collateral) were funded when `not collateral_all_ok`, resulting in lots of additional collaterals if one mn collateral was bad for any reason (spent, not funded, mn added, etc.)

## What was done?
<!--- Describe your changes in detail -->
Check status of each masternodes collateral before adding to the list of funding targets

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
On `devnet-xxxx`

## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->
None

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [x] I have assigned this pull request to a milestone
