### PR TITLE
fix: move import wallet and check

### DIFF
--- a/ansible/roles/dashd/tasks/main.yml
+++ b/ansible/roles/dashd/tasks/main.yml
@@ -81,6 +81,20 @@
     path: /etc/cron.daily/logrotate
     mode: "+x"
 
+- name: Check if wallet exists
+  stat:
+    path: "{{ dashd_home }}/.dashcore/{{ dash_network_name if dash_network == 'devnet' else 'testnet3' }}/wallets/{{ wallet_rpc_wallet_faucet }}/wallet.dat"
+  register: wallet_exists
+
+- name: Load wallets on startup
+  ansible.builtin.blockinfile:
+    path: '/etc/dash.conf'
+    insertafter: '[{{ dash_network }}]'
+    block: |
+      wallet={{ wallet_rpc_wallet_faucet }}
+      wallet={{ wallet_rpc_wallet_mno }}
+  when: enable_wallet is true and wallet_exists is true
+
 # TODO: why does this always take exactly 30 seconds on first deploy?
 - name: Start dash core
   community.docker.docker_compose:
@@ -113,14 +127,6 @@
   register: task_result
   when: enable_wallet is true
 
-- name: Load wallets on startup
-  ansible.builtin.blockinfile:
-    path: '/etc/dash.conf'
-    insertafter: '[{{ dash_network }}]'
-    block: |
-      wallet={{ wallet_rpc_wallet_faucet }}
-      wallet={{ wallet_rpc_wallet_mno }}
-  when: enable_wallet is true
 
 - name: Import faucet privkey
   ansible.builtin.command: dash-cli -rpcwallet={{ wallet_rpc_wallet_faucet }} importprivkey {{ faucet_privkey }}

--- a/ansible/roles/dashd/tasks/main.yml
+++ b/ansible/roles/dashd/tasks/main.yml
@@ -82,7 +82,7 @@
     mode: "+x"
 
 - name: Check if wallet exists
-  stat:
+  ansible.builtin.stat:
     path: "{{ dashd_home }}/.dashcore/{{ dash_network_name if dash_network == 'devnet' else 'testnet3' }}/wallets/{{ wallet_rpc_wallet_faucet }}/wallet.dat"
   register: wallet_exists
 


### PR DESCRIPTION
Fixes the import wallet issue on redeployment by moving the import above starting (so it is already there when we start)

If there is no wallet, it will *not* add to the configs. However it will then create (and import) the wallets on first loadup. 

There is a small issue where if we restart the wallet node *after* first deployment, but have not done subsequent deployments, the wallet won't be there. This is minor, and can be fixed by simply loading the wallet, I do not expect this to come up very often (mostly for failed deployments where we do a manual restart)


## How Has This Been Tested?
devnet-infratesting
