### PR TITLE
chore: update yaml octal quoting required in ansible-lint 6.13.1

### DIFF
--- a/ansible/roles/aws/tasks/main.yml
+++ b/ansible/roles/aws/tasks/main.yml
@@ -11,4 +11,4 @@
     line: '127.0.0.1 localhost {{ inventory_hostname }}'
     owner: root
     group: root
-    mode: 0644
+    mode: "0644"

--- a/ansible/roles/dash_cli/tasks/main.yml
+++ b/ansible/roles/dash_cli/tasks/main.yml
@@ -19,4 +19,4 @@
     remote_src: true
     src: /tmp/dash-cli
     dest: /usr/local/bin/dash-cli
-    mode: 0755
+    mode: "0755"

--- a/ansible/roles/dashd/tasks/main.yml
+++ b/ansible/roles/dashd/tasks/main.yml
@@ -18,7 +18,7 @@
   ansible.builtin.file:
     path: '{{ item.dir }}/.dashcore'
     state: directory
-    mode: 0755
+    mode: "0755"
     owner: '{{ item.user }}'
     group: '{{ item.group }}'
   loop: '{{ users_to_manage }}'
@@ -29,7 +29,7 @@
     dest: /etc/dash.conf
     owner: root
     group: root
-    mode: 0644
+    mode: "0644"
   register: dash_config_state
 
 - name: Symlink dash.conf to user dashcore directories to make rpc work
@@ -44,14 +44,14 @@
   ansible.builtin.file:
     path: '{{ dashd_compose_path }}'
     state: directory
-    mode: 0755
+    mode: "0755"
     recurse: true
 
 - name: Copy dashcore docker-compose file
   ansible.builtin.template:
     src: '{{ item }}.j2'
     dest: '{{ dashd_compose_path }}/{{ item }}'
-    mode: 0644
+    mode: "0644"
   loop:
     - docker-compose.yml
     - .env

--- a/ansible/roles/dashd_generate_miner/tasks/main.yml
+++ b/ansible/roles/dashd_generate_miner/tasks/main.yml
@@ -6,7 +6,7 @@
     dest: '/usr/local/bin/dashd-generate-miner.sh'
     owner: root
     group: root
-    mode: 0755
+    mode: "0755"
   register: service_result
 
 - name: Create dashd-generate-miner service
@@ -15,7 +15,7 @@
     dest: '/etc/systemd/system/dashd-generate-miner.service'
     owner: root
     group: root
-    mode: 0644
+    mode: "0644"
   register: service_result
 
 - name: Enable dashd-generate-miner

--- a/ansible/roles/docker_options/tasks/main.yml
+++ b/ansible/roles/docker_options/tasks/main.yml
@@ -4,7 +4,7 @@
   ansible.builtin.file:
     path: /etc/docker
     state: directory
-    mode: 0700
+    mode: "0700"
     owner: root
     group: root
 
@@ -14,7 +14,7 @@
     dest: '/etc/docker/daemon.json'
     owner: root
     group: root
-    mode: 0640
+    mode: "0640"
   notify: Restart docker
 
 - name: Update systemd service
@@ -22,7 +22,7 @@
   ansible.builtin.copy:
     src: '{{ item }}'
     dest: '/lib/systemd/system/{{ item }}'
-    mode: 0644
+    mode: "0644"
   loop:
     - 'docker.service'
     - 'docker.socket'
@@ -33,4 +33,4 @@
   ansible.builtin.copy:
     src: docker
     dest: /etc/default/
-    mode: 0644
+    mode: "0644"

--- a/ansible/roles/elastic_stack/tasks/generate_certs.yml
+++ b/ansible/roles/elastic_stack/tasks/generate_certs.yml
@@ -10,7 +10,7 @@
   ansible.builtin.template:
     src: 'certs/{{ item }}.j2'
     dest: '{{ bundle_path }}/{{ item }}'
-    mode: 0644
+    mode: "0644"
   loop:
     - docker-compose.yml
     - instances.yml

--- a/ansible/roles/elastic_stack/tasks/main.yml
+++ b/ansible/roles/elastic_stack/tasks/main.yml
@@ -26,7 +26,7 @@
   ansible.builtin.file:
     path: '~/tmp/ansible/{{ dash_network_name }}'
     state: directory
-    mode: 0777
+    mode: "0777"
 
 - name: Fetch generated ca
   run_once: true
@@ -58,7 +58,7 @@
   ansible.builtin.template:
     src: '{{ item }}.j2'
     dest: '{{ elastic_path }}/{{ item }}'
-    mode: 0644
+    mode: "0644"
   loop:
     - docker-compose.yml
     - elasticsearch.yml

--- a/ansible/roles/elastic_stack/tasks/volume.yml
+++ b/ansible/roles/elastic_stack/tasks/volume.yml
@@ -6,7 +6,7 @@
   ansible.builtin.file:
     path: '{{ data_path }}'
     state: directory
-    mode: 0755
+    mode: "0755"
 
 - name: Create partition
   community.general.parted:
@@ -34,4 +34,4 @@
     state: directory
     owner: ubuntu
     group: root
-    mode: 0755
+    mode: "0755"

--- a/ansible/roles/insight/tasks/main.yml
+++ b/ansible/roles/insight/tasks/main.yml
@@ -10,7 +10,7 @@
   ansible.builtin.template:
     src: '{{ item }}.j2'
     dest: '{{ insight_path }}/{{ item }}'
-    mode: 0644
+    mode: "0644"
   loop:
     - docker-compose.yml
     - dashcore-node.json

--- a/ansible/roles/mn_evo_services/tasks/main.yml
+++ b/ansible/roles/mn_evo_services/tasks/main.yml
@@ -49,7 +49,7 @@
   ansible.builtin.template:
     src: '{{ item }}.j2'
     dest: '{{ mn_evo_services_path }}/{{ item }}'
-    mode: 0644
+    mode: "0644"
   loop:
     - docker-compose.yml
     - dapi-nginx.conf

--- a/ansible/roles/mn_evo_services/tasks/tendermint.yml
+++ b/ansible/roles/mn_evo_services/tasks/tendermint.yml
@@ -6,7 +6,7 @@
     state: directory
     owner: '{{ tendermint_uid }}'
     group: '{{ tendermint_gid }}'
-    mode: 0750
+    mode: "0750"
 
 - name: Create tendermint config dir
   ansible.builtin.file:
@@ -14,7 +14,7 @@
     state: directory
     owner: '{{ tendermint_uid }}'
     group: '{{ tendermint_gid }}'
-    mode: 0750
+    mode: "0750"
 
 - name: Create tendermint data dir
   ansible.builtin.file:
@@ -22,7 +22,7 @@
     state: directory
     owner: '{{ tendermint_uid }}'
     group: '{{ tendermint_gid }}'
-    mode: 0750
+    mode: "0750"
 
 - name: Create Tendermint configs
   vars:
@@ -32,7 +32,7 @@
     dest: '{{ mn_evo_services_path }}/tendermint/config/{{ item }}'
     owner: '{{ tendermint_uid }}'
     group: '{{ tendermint_gid }}'
-    mode: 0644
+    mode: "0644"
   loop:
     - config.toml
     - genesis.json

--- a/ansible/roles/mn_find_collateral/tasks/main.yml
+++ b/ansible/roles/mn_find_collateral/tasks/main.yml
@@ -8,7 +8,7 @@
     dest: /usr/local/bin/find-collateral.py
     owner: root
     group: root
-    mode: 0755
+    mode: "0755"
 
 - name: Find collateral for {{ masternode_name ~ '/' ~ masternode.collateral.address }}
   ansible.builtin.command:

--- a/ansible/roles/mn_sentinel/tasks/main.yml
+++ b/ansible/roles/mn_sentinel/tasks/main.yml
@@ -10,7 +10,7 @@
   ansible.builtin.template:
     src: '{{ item }}'
     dest: '{{ mn_sentinel_path }}/{{ item }}'
-    mode: 0644
+    mode: "0644"
   loop:
     - docker-compose.yml
     - .env

--- a/ansible/roles/mn_status_report/tasks/main.yml
+++ b/ansible/roles/mn_status_report/tasks/main.yml
@@ -11,4 +11,4 @@
     dest: /usr/local/bin
     owner: ubuntu
     group: ubuntu
-    mode: 0755
+    mode: "0755"

--- a/ansible/roles/multifaucet/tasks/main.yml
+++ b/ansible/roles/multifaucet/tasks/main.yml
@@ -12,7 +12,7 @@
   ansible.builtin.template:
     src: '{{ item }}.j2'
     dest: '{{ dashd_home }}/multifaucet/{{ item }}'
-    mode: 0644
+    mode: "0644"
   with_items:
     - docker-compose.yml
     - init.sql
@@ -21,7 +21,7 @@
   ansible.builtin.template:
     src: '{{ item }}'
     dest: '{{ dashd_home }}/multifaucet/{{ item }}'
-    mode: 0644
+    mode: "0644"
   with_items:
     - config/db.conf.php
     - config/wallet.conf.php

--- a/ansible/roles/openvpn/tasks/main.yml
+++ b/ansible/roles/openvpn/tasks/main.yml
@@ -26,6 +26,6 @@
   ansible.builtin.copy:
     src: '{{ openvpn_config_path }}'
     dest: '../networks/{{ dash_network_name }}.ovpn'
-    mode: 0644
+    mode: "0644"
   vars:
     openvpn_config_path: '~/tmp/ansible/{{ dash_network_name }}/{{ inventory_hostname }}.ovpn'

--- a/ansible/roles/swap/tasks/main.yml
+++ b/ansible/roles/swap/tasks/main.yml
@@ -16,7 +16,7 @@
 - name: Set permissions on swap file
   ansible.builtin.file:
     path: "{{ swap_file }}"
-    mode: 0600
+    mode: "0600"
 
 - name: Format swap file
   ansible.builtin.command: mkswap {{ swap_file }}

--- a/ansible/roles/tcpdumpd/tasks/main.yml
+++ b/ansible/roles/tcpdumpd/tasks/main.yml
@@ -10,7 +10,7 @@
   ansible.builtin.template:
     src: 'tcpdump.service'
     dest: '/etc/systemd/system/tcpdumpd.service'
-    mode: 0644
+    mode: "0644"
 
 - name: Make sure tcpdump unit is running
   ansible.builtin.systemd:
@@ -22,4 +22,4 @@
   ansible.builtin.template:
     src: 'tcpdumpd'
     dest: '/etc/logrotate.d/tcpdumpd'
-    mode: 0644
+    mode: "0644"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Our linting package will update soon, causing error `yaml[octal-values]: Forbidden implicit octal value "0644"` due to changes in the way the yaml standard handles octals.

## What was done?
<!--- Describe your changes in detail -->
Quote octal values as required in current ansible-lint documentation: https://ansible-lint.readthedocs.io/rules/yaml/#octals

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
With ansible-lint 6.13.1

## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->
None

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [x] I have assigned this pull request to a milestone
