### PR TITLE
feat: specify sporks in network config

### DIFF
--- a/ansible/group_vars/all
+++ b/ansible/group_vars/all
@@ -99,6 +99,15 @@ dashd_zmq_port: 29998
 # dashd_sporkaddr:
 # dashd_sporkkey:
 
+sporks:
+  SPORK_2_INSTANTSEND_ENABLED: true
+  SPORK_3_INSTANTSEND_BLOCK_FILTERING: true
+  SPORK_9_SUPERBLOCKS_ENABLED: true
+  SPORK_17_QUORUM_DKG_ENABLED: true
+  SPORK_19_CHAINLOCKS_ENABLED: true
+  SPORK_21_QUORUM_ALL_CONNECTED: true
+  SPORK_23_QUORUM_POSE: false
+
 # You can provide your own seed node in network config. May be useful if you want to connect to another network
 dashd_seednode: '{{ hostvars[groups.seed_nodes[0]]["public_ip"] if groups.seed_nodes else none }}'
 

--- a/ansible/roles/activate_dashd_sporks/tasks/main.yml
+++ b/ansible/roles/activate_dashd_sporks/tasks/main.yml
@@ -37,3 +37,5 @@
 - name: Activate non active sporks
   ansible.builtin.command: dash-cli sporkupdate {{ item }} 0
   with_items: '{{ activate_sporks }}'
+  changed_when: true
+  when: activate_sporks | length > 0

--- a/ansible/roles/activate_dashd_sporks/tasks/main.yml
+++ b/ansible/roles/activate_dashd_sporks/tasks/main.yml
@@ -18,13 +18,22 @@
   register: active_sporks
   changed_when: active_sporks | length > 0
 
+- name: Process active sporks list
+  ansible.builtin.set_fact:
+    active_sporks_list: '{{ (active_sporks_list | default([])) + [item.key] }}'
+  when: item.value
+  with_dict: '{{ active_sporks.stdout | from_json }}'
+
+- name: Prepare target sporks list
+  ansible.builtin.set_fact:
+    target_sporks: '{{ (target_sporks | default([])) + [item.key] }}'
+  when: item.value
+  with_dict: '{{ sporks }}'
+
+- name: Prepare list of sporks to be activated
+  ansible.builtin.set_fact:
+    activate_sporks: '{{ target_sporks | difference(active_sporks_list) }}'
+
 - name: Activate non active sporks
   ansible.builtin.command: dash-cli sporkupdate {{ item }} 0
-  with_items:
-    - SPORK_2_INSTANTSEND_ENABLED
-    - SPORK_3_INSTANTSEND_BLOCK_FILTERING
-    - SPORK_9_SUPERBLOCKS_ENABLED
-    - SPORK_17_QUORUM_DKG_ENABLED
-    - SPORK_19_CHAINLOCKS_ENABLED
-    - SPORK_21_QUORUM_ALL_CONNECTED
-  when: not (active_sporks.stdout | from_json)[item]
+  with_items: '{{ activate_sporks }}'


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
v19 networks need to set spork 23 at a later point in time, so we need to be able to modify sporks in the network config

## What was done?
<!--- Describe your changes in detail -->
Move spork settings to network config, keep spork 23 disabled by default

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Against bintang, without making any changes

## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->
The ENTIRE spork object must now be specified in the network config if not applying the default object from `group_vars/all`. Is there a better way to do this?

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [x] I have assigned this pull request to a milestone
