### PR TITLE
chore: remove dapi-grpc port

### DIFF
--- a/ansible/group_vars/all
+++ b/ansible/group_vars/all
@@ -53,7 +53,6 @@ tenderdash_log_level: debug
 dapi_image: dashpay/dapi
 dapi_envoy_image: envoyproxy/envoy
 dapi_port: 3000
-# dapi_grpc_port: 3010
 
 # Insight
 insight_image: dashpay/insight

--- a/terraform/aws/security_groups.tf
+++ b/terraform/aws/security_groups.tf
@@ -283,18 +283,6 @@ resource "aws_security_group" "hp_masternode" {
     ]
   }
 
-  # DAPI GRPC
-  ingress {
-    from_port   = var.dapi_grpc_port
-    to_port     = var.dapi_grpc_port
-    protocol    = "tcp"
-    description = "DAPI Grpc"
-
-    cidr_blocks = [
-      "0.0.0.0/0",
-    ]
-  }
-
   # Tendermint P2P
   ingress {
     from_port   = var.tendermint_p2p_port

--- a/terraform/aws/services_output.tf
+++ b/terraform/aws/services_output.tf
@@ -55,14 +55,6 @@ locals {
     }
   )
 
-  service_dapi_grpc = templatefile(
-    "${path.module}/templates/services/service.tpl",
-    {
-      name = "DAPI GRPC"
-      port = var.dapi_grpc_port
-    }
-  )
-
   service_drive = templatefile(
     "${path.module}/templates/services/service.tpl",
     {

--- a/terraform/aws/variables.tf
+++ b/terraform/aws/variables.tf
@@ -51,11 +51,6 @@ variable "dapi_port" {
   default     = 3000
 }
 
-variable "dapi_grpc_port" {
-  description = "DAPI GRPC port"
-  default     = 3010
-}
-
 variable "tendermint_p2p_port" {
   description = "Tendermint P2P port"
   default     = 26656


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
DAPI no longer uses separate ports for HTTP and GRPC, it is all on port 3000

## What was done?
<!--- Describe your changes in detail -->
Remove references to dapi_grpc port 3010

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Untested

## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->
None, hopefully - we will find out while deploying v0.24 builds in coming weeks

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [x] I have assigned this pull request to a milestone
