### PR TITLE
fix: route 53 no resources found on network with 0 masternodes

### DIFF
--- a/terraform/aws/main.tf
+++ b/terraform/aws/main.tf
@@ -237,8 +237,27 @@ locals {
 }
 
 resource "random_shuffle" "dns_ips" {
-  input        = concat(aws_instance.masternode_amd.*.public_ip, aws_instance.masternode_arm.*.public_ip)
-  result_count = length(concat(aws_instance.masternode_amd.*.public_ip, aws_instance.masternode_arm.*.public_ip)) > local.dns_record_length ? local.dns_record_length : length(concat(aws_instance.masternode_amd.*.public_ip, aws_instance.masternode_arm.*.public_ip))
+  input        = concat(
+    aws_instance.masternode_amd.*.public_ip,
+    aws_instance.masternode_arm.*.public_ip,
+    aws_instance.hp_masternode_amd.*.public_ip,
+    aws_instance.hp_masternode_arm.*.public_ip
+  )
+  result_count = length(
+    concat(
+      aws_instance.masternode_amd.*.public_ip,
+      aws_instance.masternode_arm.*.public_ip,
+      aws_instance.hp_masternode_amd.*.public_ip,
+      aws_instance.hp_masternode_arm.*.public_ip
+    )
+  ) > local.dns_record_length ? local.dns_record_length : length(
+    concat(
+      aws_instance.masternode_amd.*.public_ip,
+      aws_instance.masternode_arm.*.public_ip,
+      aws_instance.hp_masternode_amd.*.public_ip,
+      aws_instance.hp_masternode_arm.*.public_ip
+    )
+  )
 }
 
 resource "aws_route53_record" "masternodes" {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
On a network with 12 HPMN and 0 MN:
```
│ Error: creating Route 53 Record: InvalidInput: Invalid request: Expected exactly one of [AliasTarget, all of [TTL, and ResourceRecords], or TrafficPolicyInstanceId], but found none in Change with [Action=CREATE, Name=seed-3.paulaner.networks.dash.org, Type=A, SetIdentifier=null]
│       status code: 400, request id: 08b8712d-d459-40e5-a5fb-04ec3ac404c7
│ 
│   with aws_route53_record.masternodes[2],
│   on main.tf line 244, in resource "aws_route53_record" "masternodes":
│  244: resource "aws_route53_record" "masternodes" {
│ 
╵
```

## What was done?
<!--- Describe your changes in detail -->
Allow public IP selection from HPMN as well as MN when shuffling IPs to use as seeds

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
On devnet-paulaner

## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->
None

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [x] I have assigned this pull request to a milestone
