### PR TITLE
fix: ssl/provider must be equal to one of the allowed values

### DIFF
--- a/ansible/roles/dashmate/templates/dashmate.json.j2
+++ b/ansible/roles/dashmate/templates/dashmate.json.j2
@@ -90,7 +90,7 @@
             },
             "ssl": {
               "enabled": true,
-              "provider": "selfSigned",
+              "provider": "self-signed",
               "providerConfigs": {
                 "zerossl": {
                   "apiKey": null,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Platform PR [#869](https://github.com/dashpay/platform/pull/869) changed the syntax of `config/platform/dapi/envoy/ssl/provider` from `selfSigned` to `self-signed`, resulting in the following error on `yarn dashmate start`:
```
 stderr: |2-
        InvalidConfigFileFormatError: Invalid
        '/home/dashmate/.dashmate/config.json' config format:
        config/platform/dapi/envoy/ssl/provider must be equal to one of the
        allowed values
```


## What was done?
<!--- Describe your changes in detail -->
Update template to use `self-signed`

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
On `devnet-sam-adams` while testing #458

## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->
None

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [x] I have assigned this pull request to a milestone
