### PR TITLE
feat!: Make EIP and EIP association optional based on a variable

### DIFF
--- a/terraform/aws/instances.tf
+++ b/terraform/aws/instances.tf
@@ -240,7 +240,7 @@ resource "aws_instance" "masternode_arm" {
 
 resource "aws_eip" "hpmn_arm_eip" {
   instance = null
-  count = var.hp_masternode_arm_count
+  count = var.create_eip ? var.hp_masternode_arm_count : 0
   
   tags = {
     Name        = "dn-${terraform.workspace}-hp-masternode-arm-${count.index+1}"
@@ -250,7 +250,7 @@ resource "aws_eip" "hpmn_arm_eip" {
 
 resource "aws_eip" "hpmn_amd_eip" {
   instance = null
-  count = var.hp_masternode_amd_count
+  count = var.create_eip ? var.hp_masternode_amd_count : 0
   tags = {
     Name        = "dn-${terraform.workspace}-hp-masternode-amd-${count.index+1}"
     DashNetwork = terraform.workspace
@@ -264,6 +264,7 @@ resource "aws_instance" "hp_masternode_amd" {
   instance_type        = "t3.medium"
   key_name             = aws_key_pair.auth.id
   iam_instance_profile = aws_iam_instance_profile.monitoring.name
+  associate_public_ip_address = !var.create_eip
 
   vpc_security_group_ids = [
     aws_security_group.default.id,
@@ -304,6 +305,7 @@ resource "aws_instance" "hp_masternode_arm" {
   instance_type        = "t4g.medium"
   key_name             = aws_key_pair.auth.id
   iam_instance_profile = aws_iam_instance_profile.monitoring.name
+  associate_public_ip_address = !var.create_eip
 
   vpc_security_group_ids = [
     aws_security_group.default.id,
@@ -337,14 +339,14 @@ resource "aws_instance" "hp_masternode_arm" {
 }
 
 resource "aws_eip_association" "arm_eip_assoc" {
-  count = var.hp_masternode_arm_count
+  count = var.create_eip ? var.hp_masternode_arm_count : 0
 
   instance_id   = aws_instance.hp_masternode_arm[count.index].id
   allocation_id = aws_eip.hpmn_arm_eip[count.index].id
 }
 
 resource "aws_eip_association" "amd_eip_assoc" {
-  count = var.hp_masternode_amd_count
+  count = var.create_eip ? var.hp_masternode_amd_count : 0
 
   instance_id   = aws_instance.hp_masternode_amd[count.index].id
   allocation_id = aws_eip.hpmn_amd_eip[count.index].id

--- a/terraform/aws/variables.tf
+++ b/terraform/aws/variables.tf
@@ -201,3 +201,9 @@ variable "volume_type" {
   description = "Type of volume to use for block devices"
   default     = "gp3"
 }
+
+variable "create_eip" {
+  description = "Whether to create an Elastic IP for the instance"
+  type        = bool
+  default     = true
+}


### PR DESCRIPTION
<pre>
feat!: Make EIP and EIP association optional based on a variable

## Issue being fixed or feature implemented
This change allows the option to create or not create Elastic IPs and EIP associations based on a variable. This provides more flexibility when deploying resources in different scenarios where EIPs are not required or when public IPs should be assigned directly.

## What was done?
- Added a new `create_eip` variable to control the creation of EIPs and EIP associations
- Updated `aws_instance` resource to conditionally assign a public IP based on the `create_eip` variable
- Updated `aws_eip_association` resource to conditionally create the association based on the `create_eip` variable

## How Has This Been Tested?
Tested by deploying resources with the `create_eip` variable set to `true` and `false` and verifying the expected behavior.

## Breaking Changes
This change introduces a new variable `create_eip`, which may require updating existing configurations to include this variable. However, the variable is set to `true` by default, so it should not affect current deployments unless explicitly set to `false`.

## Checklist:
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone
</pre>