### PR TITLE
fix: is lock smoke test expected 'false' to equal 'true'

### DIFF
--- a/test/smoke/quorum.js
+++ b/test/smoke/quorum.js
@@ -191,10 +191,10 @@ describe('Quorums', () => {
     });
 
     before('Collect instantsend info', async () => {
-      // Wait two seconds here before checking for IS locks
+      // Wait five seconds here before checking for IS locks
       // TODO: implement this.slow() and await IS ZMQ message to mark test response speed yellow/red
       await new Promise((resolve) => {
-        setTimeout(resolve, 4000);
+        setTimeout(resolve, 5000);
       });
 
       const promises = [];

--- a/test/smoke/quorum.js
+++ b/test/smoke/quorum.js
@@ -194,7 +194,7 @@ describe('Quorums', () => {
       // Wait two seconds here before checking for IS locks
       // TODO: implement this.slow() and await IS ZMQ message to mark test response speed yellow/red
       await new Promise((resolve) => {
-        setTimeout(resolve, 2000);
+        setTimeout(resolve, 4000);
       });
 
       const promises = [];


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
IS tests would time out on testnet with:
```
      AssertionError: expected 'false' to equal 'true'
      + expected - actual

      -false
      +true
      
      at Context.<anonymous> (test/smoke/quorum.js:261:76)
      at processImmediate (node:internal/timers:466:21)
```
on around half the nodes.

## What was done?
<!--- Describe your changes in detail -->
Increase wait time before checking for instantsend lock on the transaction

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [x] I have assigned this pull request to a milestone
