### PR TITLE
Fix: Move clone above enable corepack

### DIFF
--- a/ansible/roles/dashmate/tasks/main.yml
+++ b/ansible/roles/dashmate/tasks/main.yml
@@ -150,6 +150,17 @@
 #    nodejs_npm_global_packages:
 #      - name: 'dashmate@{{ dashmate_version }}'
 
+- name: Clone dashmate source
+  become: true
+  become_user: dashmate
+  ansible.builtin.git:
+    repo: 'https://github.com/dashpay/platform'
+    dest: '{{ dashmate_source_dir }}'
+    version: '{{ platform_branch }}'
+    single_branch: true
+    depth: 1
+  register: git
+
 - name: Enable corepack
   ansible.builtin.shell: |
     corepack enable
@@ -196,17 +207,6 @@
   args:
     executable: /bin/bash
   changed_when: true
-
-- name: Clone dashmate source
-  become: true
-  become_user: dashmate
-  ansible.builtin.git:
-    repo: 'https://github.com/dashpay/platform'
-    dest: '{{ dashmate_source_dir }}'
-    version: '{{ platform_branch }}'
-    single_branch: true
-    depth: 1
-  register: git
 
 # Build sources to call dashmate
 - name: Build sources


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
Enable Corepack task fails if cloning the platform repository is not done first, this would only affect new HPMNs

## What was done?
Move platform clone above corepack


## How Has This Been Tested?
Testnet


## Breaking Changes
None


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone
