### PR TITLE
fix: destroy platform tasks doesn't support the installation from package

### DIFF
--- a/ansible/roles/dashmate/tasks/delete_files.yml
+++ b/ansible/roles/dashmate/tasks/delete_files.yml
@@ -9,3 +9,8 @@
   ansible.builtin.file:
     state: absent
     path: "{{ dashmate_logs_dir }}/"
+
+- name: Delete dashmate source dir
+  ansible.builtin.file:
+    state: absent
+    path: "{{ dashmate_source_dir }}/"

--- a/ansible/roles/dashmate/tasks/main.yml
+++ b/ansible/roles/dashmate/tasks/main.yml
@@ -1,14 +1,7 @@
 ---
 
-- name: Validate configuration
-  ansible.builtin.fail:
-    msg: Either dashmate_branch or dashmate_version must be set
-  when: (dashmate_branch is defined and dashmate_version is defined) or (dashmate_branch is not defined and dashmate_version is not defined)
-
-- name: Set dashmate cmd
-  ansible.builtin.set_fact:
-    dashmate_cmd: "{{ 'yarn dashmate' if dashmate_branch is defined else 'dashmate' }}"
-    dashmate_cwd: "{{ dashmate_source_dir if dashmate_branch is defined else dashmate_home }}"
+- name: Set vars
+  ansible.builtin.import_tasks: ./set_vars.yml
 
 - name: Create dashmate group
   ansible.builtin.group:

--- a/ansible/roles/dashmate/tasks/reset_platform.yml
+++ b/ansible/roles/dashmate/tasks/reset_platform.yml
@@ -4,7 +4,7 @@
   ansible.builtin.import_tasks: ./set_vars.yml
 
 - name: Stop node
-  ansible.builtin.command: {{ dashmate_cmd }} stop
+  ansible.builtin.command: "{{ dashmate_cmd }} stop"
   become: true
   become_user: dashmate
   ignore_errors: true
@@ -14,7 +14,7 @@
   changed_when: dashmate_stop.rc == 0
 
 - name: Reset platform
-  ansible.builtin.command: {{ dashmate_cmd }} reset --platform-only --force
+  ansible.builtin.command: "{{ dashmate_cmd }} reset --platform-only --force"
   become: true
   become_user: dashmate
   args:

--- a/ansible/roles/dashmate/tasks/reset_platform.yml
+++ b/ansible/roles/dashmate/tasks/reset_platform.yml
@@ -1,20 +1,23 @@
 ---
 
+- name: Set vars
+  ansible.builtin.import_tasks: ./set_vars.yml
+
 - name: Stop node
-  ansible.builtin.command: yarn dashmate stop
+  ansible.builtin.command: {{ dashmate_cmd }} stop
   become: true
   become_user: dashmate
   ignore_errors: true
   args:
-    chdir: '{{ dashmate_source_dir }}'
+    chdir: '{{ dashmate_cwd }}'
   register: dashmate_stop
   changed_when: dashmate_stop.rc == 0
 
 - name: Reset platform
-  ansible.builtin.command: yarn dashmate reset --platform-only --force
+  ansible.builtin.command: {{ dashmate_cmd }} reset --platform-only --force
   become: true
   become_user: dashmate
   args:
-    chdir: '{{ dashmate_source_dir }}'
+    chdir: '{{ dashmate_cwd }}'
   register: dashmate_reset
   changed_when: dashmate_reset.rc == 0

--- a/ansible/roles/dashmate/tasks/set_vars.yml
+++ b/ansible/roles/dashmate/tasks/set_vars.yml
@@ -1,0 +1,11 @@
+---
+
+- name: Validate configuration
+  ansible.builtin.fail:
+    msg: Either dashmate_branch or dashmate_version must be set
+  when: (dashmate_branch is defined and dashmate_version is defined) or (dashmate_branch is not defined and dashmate_version is not defined)
+
+- name: Set dashmate vars
+  ansible.builtin.set_fact:
+    dashmate_cmd: "{{ 'yarn dashmate' if dashmate_branch is defined else 'dashmate' }}"
+    dashmate_cwd: "{{ dashmate_source_dir if dashmate_branch is defined else dashmate_home }}"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
#479 implementation doesn't cover platform destroy logic

## What was done?
<!--- Describe your changes in detail -->
- Added the dashmate package support to the platform destroy tasks

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
None

## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->
None

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [x] I have assigned this pull request to a milestone
