### PR TITLE
fix: always set associated IP to be true

### DIFF
--- a/terraform/aws/instances.tf
+++ b/terraform/aws/instances.tf
@@ -264,7 +264,7 @@ resource "aws_instance" "hp_masternode_amd" {
   instance_type        = "t3.medium"
   key_name             = aws_key_pair.auth.id
   iam_instance_profile = aws_iam_instance_profile.monitoring.name
-  associate_public_ip_address = !var.create_eip
+  associate_public_ip_address = true
 
   vpc_security_group_ids = [
     aws_security_group.default.id,
@@ -305,7 +305,7 @@ resource "aws_instance" "hp_masternode_arm" {
   instance_type        = "t4g.medium"
   key_name             = aws_key_pair.auth.id
   iam_instance_profile = aws_iam_instance_profile.monitoring.name
-  associate_public_ip_address = !var.create_eip
+  associate_public_ip_address = true
 
   vpc_security_group_ids = [
     aws_security_group.default.id,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
Issue described in PR https://github.com/dashpay/dash-network-deploy/pull/481 - this is a better fix than ignoring lifecycle changes and supersedes that PR


## What was done?
Always set associate public IP to true even if we are going to later replace with an EIP. Terraform does not track state changes correctly here (breaking standards with AWS CloudFormation which does but I digress...)

Terraform has a few long standing issues about this: 

https://github.com/hashicorp/terraform-provider-aws/issues/343

https://github.com/hashicorp/terraform/issues/9811


## How Has This Been Tested?
Devnet


## Breaking Changes
Possibly previous networks with HPMNs may need to redeploy.


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ x] I have performed a self-review of my own code
- [x ] I have commented my code, particularly in hard-to-understand areas
- [x ] I have added or updated relevant unit/integration/functional/e2e tests
- [x ] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [x ] I have assigned this pull request to a milestone
