### PR TITLE
feat: user compose to restart only changed containers

### DIFF
--- a/ansible/roles/dashmate/tasks/install.yml
+++ b/ansible/roles/dashmate/tasks/install.yml
@@ -16,3 +16,4 @@
 - name: Install dashmate package
   ansible.builtin.apt:
     deb: "{{ release_info.json.assets | selectattr('name', 'search', '_' + deb_architecture.stdout + '.deb') | map(attribute='browser_download_url') | first }}"
+    force: true

--- a/ansible/roles/dashmate/tasks/main.yml
+++ b/ansible/roles/dashmate/tasks/main.yml
@@ -159,3 +159,23 @@
   register: dashmate_start
   when: "dashmate_restart.rc != 0"
   changed_when: dashmate_start.rc == 0
+
+# Restart only changed services (only works for package-installed dashmate)
+- name: Export current dashmate config
+  ansible.builtin.shell: "{{ dashmate_cmd }} config envs > .env"
+  become: true
+  become_user: dashmate
+  args:
+    chdir: '{{ dashmate_cwd }}'
+  register: dashmate_envs
+  # when: TODO: we need to write tags for these commands
+  changed_when: dashmate_envs.rc == 0
+
+- name: Use docker compose to start only changed containers
+  ansible.builtin.shell: "LOCAL_UID=$(id -u) LOCAL_GID=$(id -g) docker compose --env-file {{ dashmate_cwd }}/.env up -d"
+  become: true
+  become_user: dashmate
+  args:
+    chdir: /usr/lib/dashmate
+  register: dashmate_compose_up
+  changed_when: dashmate_compose_up.rc == 0


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Using dashmate to manage docker containers means we are unable to restart individual services until dashmate implements the `--platform` flag to control service state targeting.

## What was done?
<!--- Describe your changes in detail -->
Implement a workaround described by @shumkov 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
On testnet

## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->
We shouldn't keep this around for long, it's hacky

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [x] I have assigned this pull request to a milestone
