### PR TITLE
chore: ensure seeders only return HPMNs

### DIFF
--- a/terraform/aws/main.tf
+++ b/terraform/aws/main.tf
@@ -238,22 +238,16 @@ locals {
 
 resource "random_shuffle" "dns_ips" {
   input = concat(
-    aws_instance.masternode_amd.*.public_ip,
-    aws_instance.masternode_arm.*.public_ip,
     var.create_eip ? aws_eip.hpmn_arm_eip.*.public_ip : [],
     var.create_eip ? aws_eip.hpmn_amd_eip.*.public_ip : []
   )
   result_count = length(
     concat(
-      aws_instance.masternode_amd.*.public_ip,
-      aws_instance.masternode_arm.*.public_ip,
       var.create_eip ? aws_eip.hpmn_arm_eip.*.public_ip : [],
       var.create_eip ? aws_eip.hpmn_amd_eip.*.public_ip : []
     )
   ) > local.dns_record_length ? local.dns_record_length : length(
     concat(
-      aws_instance.masternode_amd.*.public_ip,
-      aws_instance.masternode_arm.*.public_ip,
       var.create_eip ? aws_eip.hpmn_arm_eip.*.public_ip : [],
       var.create_eip ? aws_eip.hpmn_amd_eip.*.public_ip : []
     )

--- a/terraform/aws/main.tf
+++ b/terraform/aws/main.tf
@@ -236,6 +236,7 @@ locals {
   dns_record_length = 10 // recommended number of hosts per A record. Other way there might be problems with resolving of seeds in some regions.
 }
 
+# shuffle hpmn ips only
 resource "random_shuffle" "dns_ips" {
   input = concat(
     var.create_eip ? aws_eip.hpmn_arm_eip.*.public_ip : [],
@@ -254,6 +255,7 @@ resource "random_shuffle" "dns_ips" {
   )
 }
 
+# `seed-n` type addresses are dapi endpoints
 resource "aws_route53_record" "masternodes" {
   zone_id = data.aws_route53_zone.main_domain[0].zone_id
   name    = "seed-${count.index + 1}.${var.public_network_name}.${var.main_domain}"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
`seed-n.network.networks.dash.org` nodes incorrectly included masternodes. The nodes in these DNS entries are intended to be accessed through DNS names for DAPI endpoints only.

## What was done?
<!--- Describe your changes in detail -->
Remove masternodes from random shuffle ips

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
On testnet

## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->
Nones

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [x] I have assigned this pull request to a milestone
