### PR TITLE
fix: stop & start core instead of restart

### DIFF
--- a/ansible/roles/dashd/tasks/main.yml
+++ b/ansible/roles/dashd/tasks/main.yml
@@ -103,12 +103,16 @@
       wallet={{ wallet_rpc_wallet_mno }}
   when: enable_wallet is true and wallet_exists.stat.exists is true
 
-# TODO: why does this always take exactly 30 seconds on first deploy?
+- name: Stop dash core
+  community.docker.docker_compose:
+    project_src: '{{ dashd_compose_path }}'
+    state: absent
+    timeout: 30
+
 - name: Start dash core
   community.docker.docker_compose:
     project_src: '{{ dashd_compose_path }}'
     state: present
-    restarted: true
     pull: true
     timeout: 30
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
Instead of a regular restart of Dash Core, we need to stop & then start it due to an underlying bug that will corrupt an upgrade.


## What was done?
Stop & start instead of restart


## How Has This Been Tested?
devnet-screwdriver


## Breaking Changes
None, AFAIK


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone
