### PR TITLE
fix(terraform): InvalidInput error

### DIFF
--- a/terraform/aws/main.tf
+++ b/terraform/aws/main.tf
@@ -239,18 +239,18 @@ locals {
 # shuffle hpmn ips only
 resource "random_shuffle" "dns_ips" {
   input = concat(
-    var.create_eip ? aws_eip.hpmn_arm_eip.*.public_ip : [],
-    var.create_eip ? aws_eip.hpmn_amd_eip.*.public_ip : []
+    var.create_eip ? aws_eip.hpmn_arm_eip.*.public_ip : aws_instance.hp_masternode_arm.*.public_ip,
+    var.create_eip ? aws_eip.hpmn_amd_eip.*.public_ip : aws_instance.hp_masternode_amd.*.public_ip
   )
   result_count = length(
     concat(
-      var.create_eip ? aws_eip.hpmn_arm_eip.*.public_ip : [],
-      var.create_eip ? aws_eip.hpmn_amd_eip.*.public_ip : []
+      var.create_eip ? aws_eip.hpmn_arm_eip.*.public_ip : aws_instance.hp_masternode_arm.*.public_ip,
+      var.create_eip ? aws_eip.hpmn_amd_eip.*.public_ip : aws_instance.hp_masternode_amd.*.public_ip
     )
   ) > local.dns_record_length ? local.dns_record_length : length(
     concat(
-      var.create_eip ? aws_eip.hpmn_arm_eip.*.public_ip : [],
-      var.create_eip ? aws_eip.hpmn_amd_eip.*.public_ip : []
+      var.create_eip ? aws_eip.hpmn_arm_eip.*.public_ip : aws_instance.hp_masternode_arm.*.public_ip,
+      var.create_eip ? aws_eip.hpmn_amd_eip.*.public_ip : aws_instance.hp_masternode_amd.*.public_ip
     )
   )
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
Fix for InvalidInput error when creating a new devnet without EIPs
```
│ Error: creating Route 53 Record: InvalidInput: Invalid request: Expected exactly one of [AliasTarget, all of [TTL, and ResourceRecords], or TrafficPolicyInstanceId], but found none in Change with [Action=CREATE, Name=seed-5.kazan.rd.dash.org, Type=A, SetIdentifier=null]
│       status code: 400, request id: 698eefac-42b8-4544-a40b-647191f56c42
│ 
│   with aws_route53_record.masternodes[4],
│   on main.tf line 259, in resource "aws_route53_record" "masternodes":
│  259: resource "aws_route53_record" "masternodes" {
│
```

## What was done?
We are currently sending blank DNS records if EIPs are disabled, this PR changes it to use the public_ip as fallback if there are no EIPs on the network. 


## How Has This Been Tested?
devnet-lol


## Breaking Changes
None


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone
