### PR TITLE
feat: ELB & certs for seed addresses

### DIFF
--- a/terraform/aws/main.tf
+++ b/terraform/aws/main.tf
@@ -149,14 +149,14 @@ resource "aws_elb" "web" {
 }
 
 resource "aws_lb" "seed" {
-  name                       = "${var.public_network_name}-alb-seed"
+  name                       = "${var.public_network_name}-nlb-seed"
   internal                   = false
   load_balancer_type         = "network"
   subnets                    = aws_subnet.public.*.id
   enable_deletion_protection = false
 }
 
-resource "aws_lb_listener" "seed_listener" {
+resource "aws_lb_listener" "seed" {
   load_balancer_arn = aws_lb.seed.arn
   port              = var.dapi_port
   protocol          = "TLS"

--- a/terraform/aws/main.tf
+++ b/terraform/aws/main.tf
@@ -112,10 +112,10 @@ resource "aws_elb" "web" {
   }
 
   listener {
-    instance_port     = var.faucet_port
-    instance_protocol = "http"
-    lb_port           = var.faucet_https_port
-    lb_protocol       = "https"
+    instance_port      = var.faucet_port
+    instance_protocol  = "http"
+    lb_port            = var.faucet_https_port
+    lb_protocol        = "https"
     ssl_certificate_id = aws_acm_certificate_validation.faucet.certificate_arn
   }
 
@@ -149,11 +149,11 @@ resource "aws_elb" "web" {
 }
 
 resource "aws_lb" "seed" {
-  name               = "${var.public_network_name}-alb-seed"
-  internal           = false
-  load_balancer_type = "application"
-  security_groups    = [aws_security_group.seed.id]
-  subnets            = aws_subnet.public.*.id
+  name                       = "${var.public_network_name}-alb-seed"
+  internal                   = false
+  load_balancer_type         = "application"
+  security_groups            = [aws_security_group.seed.id]
+  subnets                    = aws_subnet.public.*.id
   enable_deletion_protection = false
 }
 
@@ -199,12 +199,12 @@ resource "aws_lb_target_group_attachment" "attach_instances_arm" {
 }
 
 variable "domains" {
-  type        = list(string)
-  default     = ["seed-1", "seed-2", "seed-3", "seed-4", "seed-5"]
+  type    = list(string)
+  default = ["seed-1", "seed-2", "seed-3", "seed-4", "seed-5"]
 }
 
 resource "aws_route53_record" "seeds" {
-  count = length(var.domains)
+  count   = length(var.domains)
   zone_id = data.aws_route53_zone.main_domain[0].zone_id
   name    = "${var.domains[count.index]}.${var.public_network_name}.${var.main_domain}"
   type    = "A"

--- a/terraform/aws/main.tf
+++ b/terraform/aws/main.tf
@@ -177,13 +177,13 @@ resource "aws_lb_target_group" "seed" {
   vpc_id   = aws_vpc.default.id
 }
 
-resource "aws_lb_target_group_attachment" "attach_instances_amd" {
+resource "aws_lb_target_group_attachment" "amd_hpmns" {
   count            = var.hp_masternode_amd_count
   target_group_arn = aws_lb_target_group.seed.arn
   target_id        = aws_instance.hp_masternode_amd[count.index].id
 }
 
-resource "aws_lb_target_group_attachment" "attach_instances_arm" {
+resource "aws_lb_target_group_attachment" "arm_hpmns" {
   count            = var.hp_masternode_arm_count
   target_group_arn = aws_lb_target_group.seed.arn
   target_id        = aws_instance.hp_masternode_arm[count.index].id

--- a/terraform/aws/main.tf
+++ b/terraform/aws/main.tf
@@ -198,15 +198,10 @@ resource "aws_lb_target_group_attachment" "attach_instances_arm" {
   target_id        = aws_instance.hp_masternode_arm[count.index].id
 }
 
-variable "domains" {
-  type    = list(string)
-  default = ["seed-1", "seed-2", "seed-3", "seed-4", "seed-5"]
-}
-
 resource "aws_route53_record" "seeds" {
-  count   = length(var.domains)
+  count   = length(var.main_domain) > 1 ? 5 : 0
   zone_id = data.aws_route53_zone.main_domain[0].zone_id
-  name    = "${var.domains[count.index]}.${var.public_network_name}.${var.main_domain}"
+  name    = "seed-${count.index + 1}.${var.public_network_name}.${var.main_domain}"
   type    = "A"
 
   alias {

--- a/terraform/aws/main.tf
+++ b/terraform/aws/main.tf
@@ -239,18 +239,18 @@ locals {
 # shuffle hpmn ips only
 resource "random_shuffle" "dns_ips" {
   input = concat(
-    var.create_eip ? aws_eip.hpmn_arm_eip.*.public_ip : [],
-    var.create_eip ? aws_eip.hpmn_amd_eip.*.public_ip : []
+    var.create_eip ? aws_eip.hpmn_arm_eip.*.public_ip : aws_instance.hp_masternode_arm.*.public_ip,
+    var.create_eip ? aws_eip.hpmn_amd_eip.*.public_ip : aws_instance.hp_masternode_amd.*.public_ip
   )
   result_count = length(
     concat(
-      var.create_eip ? aws_eip.hpmn_arm_eip.*.public_ip : [],
-      var.create_eip ? aws_eip.hpmn_amd_eip.*.public_ip : []
+      var.create_eip ? aws_eip.hpmn_arm_eip.*.public_ip : aws_instance.hp_masternode_arm.*.public_ip,
+      var.create_eip ? aws_eip.hpmn_amd_eip.*.public_ip : aws_instance.hp_masternode_amd.*.public_ip
     )
   ) > local.dns_record_length ? local.dns_record_length : length(
     concat(
-      var.create_eip ? aws_eip.hpmn_arm_eip.*.public_ip : [],
-      var.create_eip ? aws_eip.hpmn_amd_eip.*.public_ip : []
+      var.create_eip ? aws_eip.hpmn_arm_eip.*.public_ip : aws_instance.hp_masternode_arm.*.public_ip,
+      var.create_eip ? aws_eip.hpmn_amd_eip.*.public_ip : aws_instance.hp_masternode_amd.*.public_ip
     )
   )
 }

--- a/terraform/aws/main.tf
+++ b/terraform/aws/main.tf
@@ -159,7 +159,7 @@ resource "aws_lb" "seed-elb" {
 
 resource "aws_lb_listener" "listener" {
   load_balancer_arn = aws_lb.seed-elb.arn
-  port              = 443
+  port              = var.dapi_port
   protocol          = "HTTPS"
   ssl_policy        = "ELBSecurityPolicy-2016-08"
   certificate_arn   = aws_acm_certificate.cert-seed.arn
@@ -172,7 +172,7 @@ resource "aws_lb_listener" "listener" {
 
 resource "aws_lb_target_group" "tg-seed" {
   name     = "${var.public_network_name}-tg-seed"
-  port     = 3001
+  port     = var.dapi_port
   protocol = "HTTP"
   vpc_id   = aws_vpc.default.id
 

--- a/terraform/aws/main.tf
+++ b/terraform/aws/main.tf
@@ -175,15 +175,6 @@ resource "aws_lb_target_group" "seed" {
   port     = var.dapi_port
   protocol = "HTTP"
   vpc_id   = aws_vpc.default.id
-
-  health_check {
-    enabled             = true
-    interval            = 30
-    path                = "/"
-    timeout             = 5
-    healthy_threshold   = 2
-    unhealthy_threshold = 2
-  }
 }
 
 resource "aws_lb_target_group_attachment" "attach_instances_amd" {
@@ -207,7 +198,9 @@ resource "aws_route53_record" "seeds" {
   alias {
     name                   = aws_lb.seed.dns_name
     zone_id                = aws_lb.seed.zone_id
-    evaluate_target_health = true
+    # TODO: enable health checks
+    # https://www.envoyproxy.io/docs/envoy/latest/operations/admin#get--ready
+    evaluate_target_health = false
   }
 }
 

--- a/terraform/aws/main.tf
+++ b/terraform/aws/main.tf
@@ -173,7 +173,7 @@ resource "aws_lb_listener" "seed_listener" {
 resource "aws_lb_target_group" "seed" {
   name     = "${var.public_network_name}-tg-seed"
   port     = var.dapi_port
-  protocol = "HTTP"
+  protocol = "HTTPS"
   vpc_id   = aws_vpc.default.id
 }
 

--- a/terraform/aws/main.tf
+++ b/terraform/aws/main.tf
@@ -148,6 +148,74 @@ resource "aws_elb" "web" {
   }
 }
 
+resource "aws_lb" "seed-elb" {
+  name               = "${var.public_network_name}-elb-seed"
+  internal           = false
+  load_balancer_type = "application"
+  security_groups    = [aws_security_group.sg-seed.id]
+  subnets            = aws_subnet.public.*.id
+  enable_deletion_protection = false
+}
+
+resource "aws_lb_listener" "listener" {
+  load_balancer_arn = aws_lb.seed-elb.arn
+  port              = 443
+  protocol          = "HTTPS"
+  ssl_policy        = "ELBSecurityPolicy-2016-08"
+  certificate_arn   = aws_acm_certificate.cert-seed.arn
+
+  default_action {
+    type             = "forward"
+    target_group_arn = aws_lb_target_group.tg-seed.arn
+  }
+}
+
+resource "aws_lb_target_group" "tg-seed" {
+  name     = "${var.public_network_name}-tg-seed"
+  port     = 3001
+  protocol = "HTTP"
+  vpc_id   = aws_vpc.default.id
+
+  health_check {
+    enabled             = true
+    interval            = 30
+    path                = "/"
+    timeout             = 5
+    healthy_threshold   = 2
+    unhealthy_threshold = 2
+  }
+}
+
+resource "aws_lb_target_group_attachment" "attach_instances_amd" {
+  count            = var.hp_masternode_amd_count
+  target_group_arn = aws_lb_target_group.tg-seed.arn
+  target_id        = aws_instance.hp_masternode_amd[count.index].id
+}
+
+resource "aws_lb_target_group_attachment" "attach_instances_arm" {
+  count            = var.hp_masternode_arm_count
+  target_group_arn = aws_lb_target_group.tg-seed.arn
+  target_id        = aws_instance.hp_masternode_arm[count.index].id
+}
+
+variable "domains" {
+  type        = list(string)
+  default     = ["seed-1", "seed-2", "seed-3", "seed-4", "seed-5"]
+}
+
+resource "aws_route53_record" "seeds" {
+  count = length(var.domains)
+  zone_id = data.aws_route53_zone.main_domain[0].zone_id
+  name    = "${var.domains[count.index]}.${var.public_network_name}.${var.main_domain}"
+  type    = "A"
+
+  alias {
+    name                   = aws_lb.seed-elb.dns_name
+    zone_id                = aws_lb.seed-elb.zone_id
+    evaluate_target_health = true
+  }
+}
+
 resource "aws_acm_certificate" "faucet" {
   domain_name       = "faucet.${var.public_network_name}.${var.main_domain}"
   validation_method = "DNS"
@@ -256,14 +324,47 @@ resource "random_shuffle" "dns_ips" {
 }
 
 # `seed-n` type addresses are dapi endpoints
-resource "aws_route53_record" "masternodes" {
-  zone_id = data.aws_route53_zone.main_domain[0].zone_id
-  name    = "seed-${count.index + 1}.${var.public_network_name}.${var.main_domain}"
-  type    = "A"
-  ttl     = "300"
-  records = random_shuffle.dns_ips.result
 
-  count = length(var.main_domain) > 1 ? 5 : 0
+resource "aws_acm_certificate" "cert-seed" {
+  domain_name       = "seed-1.${var.public_network_name}.${var.main_domain}"
+  validation_method = "DNS"
+
+  subject_alternative_names = [
+    "seed-2.${var.public_network_name}.${var.main_domain}",
+    "seed-3.${var.public_network_name}.${var.main_domain}",
+    "seed-4.${var.public_network_name}.${var.main_domain}",
+    "seed-5.${var.public_network_name}.${var.main_domain}"
+  ]
+
+  tags = {
+    Name = "seed.${var.public_network_name}.${var.main_domain}"
+  }
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+resource "aws_route53_record" "cert_seed_validation" {
+  for_each = {
+    for dvo in aws_acm_certificate.cert-seed.domain_validation_options : dvo.domain_name => {
+      name   = dvo.resource_record_name
+      record = dvo.resource_record_value
+      type   = dvo.resource_record_type
+    }
+  }
+
+  allow_overwrite = true
+  name            = each.value.name
+  records         = [each.value.record]
+  ttl             = 60
+  type            = each.value.type
+  zone_id         = data.aws_route53_zone.main_domain[0].zone_id
+}
+
+resource "aws_acm_certificate_validation" "cert-seed" {
+  certificate_arn         = aws_acm_certificate.cert-seed.arn
+  validation_record_fqdns = [for record in aws_route53_record.cert_seed_validation : record.fqdn]
 }
 
 resource "aws_key_pair" "auth" {

--- a/terraform/aws/security_groups.tf
+++ b/terraform/aws/security_groups.tf
@@ -463,7 +463,7 @@ resource "aws_security_group" "seed" {
   vpc_id      = aws_vpc.default.id
 
   ingress {
-    description = "TLS from VPC"
+    description = "DAPI from internet"
     from_port   = var.dapi_port
     to_port     = var.dapi_port
     protocol    = "tcp"

--- a/terraform/aws/security_groups.tf
+++ b/terraform/aws/security_groups.tf
@@ -445,7 +445,7 @@ resource "aws_security_group" "vpn" {
   }
 }
 
-resource "aws_security_group" "sg-seed" {
+resource "aws_security_group" "seed" {
   name        = "seed-1"
   description = "Allow inbound traffic on DAPI port and all outbound traffic"
   vpc_id      = aws_vpc.default.id

--- a/terraform/aws/security_groups.tf
+++ b/terraform/aws/security_groups.tf
@@ -444,3 +444,28 @@ resource "aws_security_group" "vpn" {
     DashNetwork = terraform.workspace
   }
 }
+
+resource "aws_security_group" "sg-seed" {
+  name        = "seed-1"
+  description = "Allow inbound traffic on port 443 and all outbound traffic"
+  vpc_id      = aws_vpc.default.id
+
+  ingress {
+    description = "TLS from VPC"
+    from_port   = 443
+    to_port     = 443
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  tags = {
+    Name = "seed-1"
+  }
+}

--- a/terraform/aws/security_groups.tf
+++ b/terraform/aws/security_groups.tf
@@ -470,13 +470,6 @@ resource "aws_security_group" "seed" {
     cidr_blocks = ["0.0.0.0/0"]
   }
 
-  egress {
-    from_port   = 0
-    to_port     = 0
-    protocol    = "-1"
-    cidr_blocks = ["0.0.0.0/0"]
-  }
-
   tags = {
     Name = "seed-1"
   }

--- a/terraform/aws/security_groups.tf
+++ b/terraform/aws/security_groups.tf
@@ -447,13 +447,13 @@ resource "aws_security_group" "vpn" {
 
 resource "aws_security_group" "sg-seed" {
   name        = "seed-1"
-  description = "Allow inbound traffic on port 443 and all outbound traffic"
+  description = "Allow inbound traffic on DAPI port and all outbound traffic"
   vpc_id      = aws_vpc.default.id
 
   ingress {
     description = "TLS from VPC"
-    from_port   = 443
-    to_port     = 443
+    from_port   = var.dapi_port
+    to_port     = var.dapi_port
     protocol    = "tcp"
     cidr_blocks = ["0.0.0.0/0"]
   }

--- a/terraform/aws/security_groups.tf
+++ b/terraform/aws/security_groups.tf
@@ -446,8 +446,8 @@ resource "aws_security_group" "vpn" {
 }
 
 resource "aws_security_group" "seed" {
-  name        = "seed-1"
-  description = "Allow inbound traffic on DAPI port and all outbound traffic"
+  name        = "${terraform.workspace}-seed"
+  description = "DAPI access"
   vpc_id      = aws_vpc.default.id
 
   ingress {

--- a/test/smoke/dapi.js
+++ b/test/smoke/dapi.js
@@ -4,7 +4,7 @@ const getNetworkConfig = require('../../lib/test/getNetworkConfig');
 
 const { variables, inventory } = getNetworkConfig();
 
-describe.only('DAPI', () => {
+describe('DAPI', () => {
   describe('All nodes', () => {
   // Set up vars and functions to hold DAPI responses
     const bestBlockHash = {};

--- a/test/smoke/dapi.js
+++ b/test/smoke/dapi.js
@@ -4,7 +4,7 @@ const getNetworkConfig = require('../../lib/test/getNetworkConfig');
 
 const { variables, inventory } = getNetworkConfig();
 
-describe('DAPI', () => {
+describe.only('DAPI', () => {
   describe('All nodes', () => {
   // Set up vars and functions to hold DAPI responses
     const bestBlockHash = {};
@@ -14,6 +14,8 @@ describe('DAPI', () => {
     const dataContract = {};
     const dataContractError = {};
 
+    const hosts = ['seed-1.testnet.networks.dash.org', 'seed-2.testnet.networks.dash.org', 'seed-3.testnet.networks.dash.org', 'seed-4.testnet.networks.dash.org', 'seed-5.testnet.networks.dash.org'];
+
     before('Collect blockhash, status and data contract info and errors', function func() {
       this.timeout(120000); // set mocha timeout
 
@@ -22,13 +24,13 @@ describe('DAPI', () => {
       }
 
       const promises = [];
-      for (const hostName of inventory.hp_masternodes?.hosts ?? []) {
+      for (const hostName of hosts) {
         const timeout = 15000; // set individual dapi client timeout
         const unknownContractId = Buffer.alloc(32).fill(1);
 
         const dapiAddress = {
           protocol: 'https',
-          host: inventory.meta.hostvars[hostName].public_ip,
+          host: hostName,
           port: variables.dapi_port,
           allowSelfSignedCertificate: variables.dashmate_platform_dapi_envoy_ssl_provider !== 'zerossl',
         };
@@ -71,7 +73,7 @@ describe('DAPI', () => {
       return Promise.all(promises).catch(() => Promise.resolve());
     });
 
-    for (const hostName of inventory.hp_masternodes?.hosts ?? []) {
+    for (const hostName of hosts) {
       describe(hostName, () => {
         it('should return data from Core', async () => {
           if (bestBlockHashError[hostName]) {

--- a/test/smoke/dapi.js
+++ b/test/smoke/dapi.js
@@ -6,7 +6,7 @@ const { variables, inventory } = getNetworkConfig();
 
 describe('DAPI', () => {
   describe('All nodes', () => {
-  // Set up vars and functions to hold DAPI responses
+    // Set up vars and functions to hold DAPI responses
     const bestBlockHash = {};
     const bestBlockHashError = {};
     const status = {};
@@ -14,7 +14,13 @@ describe('DAPI', () => {
     const dataContract = {};
     const dataContractError = {};
 
-    const hosts = ['seed-1.testnet.networks.dash.org', 'seed-2.testnet.networks.dash.org', 'seed-3.testnet.networks.dash.org', 'seed-4.testnet.networks.dash.org', 'seed-5.testnet.networks.dash.org'];
+    const hosts = [
+      'seed-1.testnet.networks.dash.org',
+      'seed-2.testnet.networks.dash.org',
+      'seed-3.testnet.networks.dash.org',
+      'seed-4.testnet.networks.dash.org',
+      'seed-5.testnet.networks.dash.org'
+    ];
 
     before('Collect blockhash, status and data contract info and errors', function func() {
       this.timeout(120000); // set mocha timeout


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
The feature here is the creation and configuration of an AWS Elastic Load Balancer (ELB), ACM Certificate, Route53 Record and Security Group using Terraform. This setup is required to make seed-*.testnet.networks.dash.org accessible over HTTPS since the old method will not work while DAPI has differing certificates.


## What was done?
New ELB for seeds with the correct certificates, adding HPMNs as backends on port 3001. 


## How Has This Been Tested?
devnet-dude


## Breaking Changes
N/A


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone
