### PR TITLE
feat: store zerossl privkeys in inventory

### DIFF
--- a/ansible/roles/dashmate/tasks/main.yml
+++ b/ansible/roles/dashmate/tasks/main.yml
@@ -133,6 +133,88 @@
   register: dashmate_envs
   changed_when: dashmate_envs.rc == 0
 
+# - name: Check if private key already exists
+
+- name: Create ssl dir
+  ansible.builtin.file:
+    path: '{{ dashmate_home }}/ssl/{{ dash_network_name }}'
+    state: directory
+    owner: '{{ dashmate_user }}'
+    group: '{{ dashmate_group }}'
+    recurse: true
+    mode: "0755"
+
+- name: Generate PEM format private key
+  community.crypto.openssl_privatekey:
+    path: '{{ dashmate_home }}/ssl/{{ dash_network_name }}/private.key'
+    owner: '{{ dashmate_user }}'
+    group: '{{ dashmate_group }}'
+
+- name: Debug cert content
+  ansible.builtin.command: cat '{{ dashmate_home }}/ssl/{{ dash_network_name }}/private.key'
+
+# Double escape newlines to prevent ansible.builtin.lineinfile from interpreting them as line breaks when adding to inventory later
+- name: Remove line breaks from private key
+  ansible.builtin.shell: |
+    awk 'NF {sub(/\r/, ""); printf "%s\\\\n",$0;}' {{ dashmate_home }}/ssl/{{ dash_network_name }}/private.key
+  register: zerossl_oneline_private_key
+
+- name: Write single line to file
+  ansible.builtin.template: 
+    src: 'oneline_debug.j2'
+    dest: '{{ dashmate_home }}/ssl/{{ dash_network_name }}/private.oneline'
+    owner: '{{ dashmate_user }}'
+    group: '{{ dashmate_group }}'
+    mode: "0644"
+
+- name: Write oneline to inventory
+  become: false
+  delegate_to: localhost
+  ansible.builtin.lineinfile:
+    path: ../networks/{{ dash_network_name }}.inventory # relative to playbook
+    regexp: '^({{ inventory_hostname }} (?!.*privkey=).*)'
+    line: '\1 privkey={{ zerossl_oneline_private_key.stdout | quote }}'
+    backrefs: true
+
+- name: Get oneline from inventory
+  become: false
+  delegate_to: localhost
+  ansible.builtin.shell: |
+    grep -Po '(?<=privkey=).*' ../networks/{{ dash_network_name }}.inventory
+  register: oneline_from_inventory
+
+- name: Debug oneline from inventory
+  ansible.builtin.debug:
+    var: oneline_from_inventory.stdout
+
+# Note sure why this doesn't make newlines
+- name: Write single line to file as many lines
+  ansible.builtin.template: 
+    src: 'multiline_debug.j2'
+    dest: '{{ dashmate_home }}/ssl/{{ dash_network_name }}/private.frominventory'
+    newline_sequence: '\n'
+    owner: '{{ dashmate_user }}'
+    group: '{{ dashmate_group }}'
+    mode: "0644"
+
+# Todo: remove fix newlines
+- name: Fix newlines
+  ansible.builtin.replace:
+    path: '{{ dashmate_home }}/ssl/{{ dash_network_name }}/private.frominventory'
+    regexp: '\\n'
+    replace: '\n'
+
+# Todo: remove fix quotes
+- name: Fix quotes
+  ansible.builtin.replace:
+    path: '{{ dashmate_home }}/ssl/{{ dash_network_name }}/private.frominventory'
+    regexp: "'"
+    replace: ""
+
+- name: Debug
+  ansible.builtin.debug:
+    var:  "{{ zerossl_oneline_private_key.stdout | replace('\\n', '\n') }}"
+
 - name: Obtain ZeroSSL certificate for DAPI
   ansible.builtin.command: "{{ dashmate_cmd }} ssl obtain --verbose"
   become: true

--- a/ansible/roles/dashmate/templates/multiline_debug.j2
+++ b/ansible/roles/dashmate/templates/multiline_debug.j2
@@ -1,0 +1,1 @@
+{{ oneline_from_inventory.stdout }}

--- a/ansible/roles/dashmate/templates/oneline_debug.j2
+++ b/ansible/roles/dashmate/templates/oneline_debug.j2
@@ -1,0 +1,1 @@
+{{ zerossl_oneline_private_key.stdout }}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
RSA privkeys need to be stored in inventory in order to reuse previously generated ZeroSSL certs in dashmate

## What was done?
<!--- Describe your changes in detail -->
Implement generating generating privkeys, storing in inventory, and retrieving from inventory

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
On testnet

## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [x] I have assigned this pull request to a milestone
