### PR TITLE
fix: core debug log permissions

### DIFF
--- a/ansible/roles/dashmate/tasks/main.yml
+++ b/ansible/roles/dashmate/tasks/main.yml
@@ -48,7 +48,7 @@
     state: directory
     owner: '{{ dashmate_user }}'
     group: '{{ dashmate_group }}'
-    mode: "0755"
+    recurse: true
 
 - name: Configure log rotation
   ansible.builtin.include_role:

--- a/ansible/roles/dashmate/tasks/main.yml
+++ b/ansible/roles/dashmate/tasks/main.yml
@@ -48,7 +48,6 @@
     state: directory
     owner: '{{ dashmate_user }}'
     group: '{{ dashmate_group }}'
-    recurse: true
     mode: "0755"
 
 - name: Configure log rotation


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
If deploy tool was run for a second time after dashmate had started, and then dashmate was restarted, core would fail to start with error `Error: Could not open debug log file /var/log/dash/core.log`

## What was done?
<!--- Describe your changes in detail -->
Don't recursively set permissions on directory contents

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
On testnet

## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->
None

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [x] I have assigned this pull request to a milestone
