### PR TITLE
fix: ssl dir missing for zerossl

### DIFF
--- a/ansible/roles/dashmate/tasks/ssl/self_signed.yml
+++ b/ansible/roles/dashmate/tasks/ssl/self_signed.yml
@@ -2,13 +2,11 @@
 
 - name: Create dashmate ssl directory
   ansible.builtin.file:
-    path: '{{ item }}'
+    path: '{{ dashmate_config_dir }}/ssl/{{ dash_network_name }}'
     state: directory
     owner: '{{ dashmate_user }}'
     group: '{{ dashmate_group }}'
     mode: "0750"
-  loop:
-    - '{{ dashmate_config_dir }}/ssl/{{ dash_network_name }}'
 
 - name: Generate an OpenSSL private key
   community.crypto.openssl_privatekey:

--- a/ansible/roles/dashmate/tasks/ssl/zerossl.yml
+++ b/ansible/roles/dashmate/tasks/ssl/zerossl.yml
@@ -9,6 +9,14 @@
     dashmate_zerossl_private_key_file_name: "private.key"
     dashmate_zerossl_bundle_file_name: "bundle.crt"
 
+- name: Create dashmate ssl directory
+  ansible.builtin.file:
+    path: '{{ dashmate_config_dir }}/ssl/{{ dash_network_name }}'
+    state: directory
+    owner: '{{ dashmate_user }}'
+    group: '{{ dashmate_group }}'
+    mode: "0750"
+
 # Set certificate ID to dashmate config
 
 - name: Check SSM parameter store for ZeroSSL certificate ID


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
When deploying Zerossl on evonodes for the first time, error: `msg: Destination directory /home/dashmate/.dashmate/ssl/testnet does not exist`

## What was done?
<!--- Describe your changes in detail -->
Ensure directory exists

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
On testnet 

## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->
None

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [x] I have assigned this pull request to a milestone
