### PR TITLE
fix: dashmate config changed on every run

### DIFF
--- a/ansible/roles/dashmate/tasks/main.yml
+++ b/ansible/roles/dashmate/tasks/main.yml
@@ -107,6 +107,19 @@
   ansible.builtin.set_fact:
     dashmate_config_version: "{{ (dashmate_version_result.stdout | split(' ') | first() | split('/'))[1] }}"
 
+- name: Retrieve existing ZeroSSL certificate ID
+  ansible.builtin.command: "{{ dashmate_cmd }} config get platform.dapi.envoy.ssl.providerConfigs.zerossl.id"
+  become: true
+  become_user: dashmate
+  args:
+    chdir: '{{ dashmate_cwd }}'
+  register: dashmate_zerossl_id_result
+  changed_when: dashmate_zerossl_id_result.rc == 0
+
+- name: Extract ZeroSSL certificate ID
+  ansible.builtin.set_fact:
+    dashmate_zerossl_config_certificate_id: "{{ dashmate_zerossl_id_result.stdout }}"
+
 - name: Write dashmate config file
   vars:
     template_bootstrap_peers: "{{ groups.seed_nodes | reject('equalto', inventory_hostname) }}"

--- a/ansible/roles/dashmate/tasks/ssl/zerossl.yml
+++ b/ansible/roles/dashmate/tasks/ssl/zerossl.yml
@@ -23,7 +23,7 @@
   delegate_to: localhost
   become: false
   ansible.builtin.set_fact:
-    dashmate_zerossl_certificate_id: "{{ lookup('aws_ssm', '{{ dashmate_zerossl_ssm_path }}-id', on_missing='skip') }}"
+    dashmate_zerossl_ssm_certificate_id: "{{ lookup('aws_ssm', '{{ dashmate_zerossl_ssm_path }}-id', on_missing='skip') }}"
 
 - name: Set ZeroSSL certificate ID to dashmate config from SSM
   ansible.builtin.command: "{{ dashmate_cmd }} config set {{ dashmate_zerossl_config_path }}.id {{ dashmate_zerossl_certificate_id }}"
@@ -33,7 +33,9 @@
     chdir: '{{ dashmate_cwd }}'
   register: dashmate_zerossl_id
   changed_when: dashmate_zerossl_id.rc == 0
-  when: dashmate_zerossl_certificate_id != ''
+  when: 
+    - dashmate_zerossl_ssm_certificate_id != ''
+    - dashmate_zerossl_ssm_certificate_id != dashmate_zerossl_config_certificate_id
 
 # Copy ZeroSSL files if they are not present
 
@@ -54,7 +56,7 @@
     - '{{ dashmate_zerossl_csr_file_name }}'
   when: >
     not zero_ssl_files.stat.exists and
-    dashmate_zerossl_certificate_id != ''
+    dashmate_zerossl_ssm_certificate_id != ''
 
 # Create a new ZeroSSL certificate if it is not present
 # or download bundle if it's not exist
@@ -73,7 +75,7 @@
   register: dashmate_obtain
   changed_when: dashmate_obtain.rc == 0
   when: >
-    dashmate_zerossl_certificate_id == '' or
+    dashmate_zerossl_ssm_certificate_id == '' or
     not zero_ssl_bundle_file.stat.exists
 
 # Save new ZeroSSL information to SSM
@@ -86,7 +88,7 @@
     chdir: '{{ dashmate_cwd }}'
   register: dashmate_zerossl_id
   changed_when: dashmate_zerossl_id.rc == 0
-  when: dashmate_zerossl_certificate_id == ''
+  when: dashmate_zerossl_ssm_certificate_id == ''
 
 - name: Update ZeroSSL certificate ID in AWS SSM parameter store
   delegate_to: localhost
@@ -94,19 +96,19 @@
   community.aws.ssm_parameter:
     name: '{{ dashmate_zerossl_ssm_path }}-id'
     value: '{{ dashmate_zerossl_id.stdout }}'
-  when: dashmate_zerossl_certificate_id == ''
+  when: dashmate_zerossl_ssm_certificate_id == ''
 
 - name: Read new generated ZeroSSL private key file to variable
   ansible.builtin.slurp:
     src: '{{ dashmate_zerossl_keys_path }}/{{ dashmate_zerossl_private_key_file_name }}'
   register: dashmate_zerossl_private_key_file
-  when: dashmate_zerossl_certificate_id == ''
+  when: dashmate_zerossl_ssm_certificate_id == ''
 
 - name: Read new generated ZeroSSL CSR file to variable
   ansible.builtin.slurp:
     src: '{{ dashmate_zerossl_keys_path }}/{{ dashmate_zerossl_csr_file_name }}'
   register: dashmate_zerossl_csr_file
-  when: dashmate_zerossl_certificate_id == ''
+  when: dashmate_zerossl_ssm_certificate_id == ''
 
 - name: Set new generated ZeroSSL CSR and private key files
   ansible.builtin.set_fact:
@@ -115,7 +117,7 @@
         content: '{{ dashmate_zerossl_private_key_file.content | b64decode }}'
       - name: "{{ dashmate_zerossl_csr_file_name }}"
         content: '{{ dashmate_zerossl_csr_file.content | b64decode }}'
-  when: dashmate_zerossl_certificate_id == ''
+  when: dashmate_zerossl_ssm_certificate_id == ''
 
 - name: Update ZeroSSL private key and CSR files in AWS SSM parameter store
   delegate_to: localhost
@@ -124,4 +126,4 @@
     name: '{{ dashmate_zerossl_ssm_path }}-{{ item.name }}'
     value: '{{ item.content }}'
   loop: '{{ dashmate_zerossl_files }}'
-  when: dashmate_zerossl_certificate_id == ''
+  when: dashmate_zerossl_ssm_certificate_id == ''

--- a/ansible/roles/dashmate/tasks/ssl/zerossl.yml
+++ b/ansible/roles/dashmate/tasks/ssl/zerossl.yml
@@ -33,7 +33,7 @@
     chdir: '{{ dashmate_cwd }}'
   register: dashmate_zerossl_id
   changed_when: dashmate_zerossl_id.rc == 0
-  when: 
+  when:
     - dashmate_zerossl_ssm_certificate_id != ''
     - dashmate_zerossl_ssm_certificate_id != dashmate_zerossl_config_certificate_id
 

--- a/ansible/roles/dashmate/templates/dashmate.json.j2
+++ b/ansible/roles/dashmate/templates/dashmate.json.j2
@@ -108,7 +108,7 @@
               "provider": "{{ dashmate_platform_dapi_envoy_ssl_provider }}",
               "providerConfigs": {
                 "zerossl": {
-                  "apiKey": {% if dashmate_platform_dapi_envoy_ssl_provider_config_zerossl_api_key is not none and dashmate_platform_dapi_envoy_ssl_provider_config_zerossl_api_key != '' %}"{{ dashmate_platform_dapi_envoy_ssl_provider_config_zerossl_api_key }}"{% else %}`{% endif %},
+                  "apiKey": {% if dashmate_platform_dapi_envoy_ssl_provider_config_zerossl_api_key is not none and dashmate_platform_dapi_envoy_ssl_provider_config_zerossl_api_key != '' %}"{{ dashmate_platform_dapi_envoy_ssl_provider_config_zerossl_api_key }}"{% else %}null{% endif %},
                   "id": {% if dashmate_zerossl_config_certificate_id != 'null' %}"{{ dashmate_zerossl_config_certificate_id }}"{% else %}null{% endif +%}
                 }
               }

--- a/ansible/roles/dashmate/templates/dashmate.json.j2
+++ b/ansible/roles/dashmate/templates/dashmate.json.j2
@@ -108,8 +108,8 @@
               "provider": "{{ dashmate_platform_dapi_envoy_ssl_provider }}",
               "providerConfigs": {
                 "zerossl": {
-                  "apiKey": {% if dashmate_platform_dapi_envoy_ssl_provider_config_zerossl_api_key is not none and dashmate_platform_dapi_envoy_ssl_provider_config_zerossl_api_key != '' %}"{{ dashmate_platform_dapi_envoy_ssl_provider_config_zerossl_api_key }}"{% else %}null{% endif %},
-                  "id": null
+                  "apiKey": {% if dashmate_platform_dapi_envoy_ssl_provider_config_zerossl_api_key is not none and dashmate_platform_dapi_envoy_ssl_provider_config_zerossl_api_key != '' %}"{{ dashmate_platform_dapi_envoy_ssl_provider_config_zerossl_api_key }}"{% else %}`{% endif %},
+                  "id": {% if dashmate_zerossl_config_certificate_id != 'null' %}"{{ dashmate_zerossl_config_certificate_id }}"{% else %}null{% endif +%}
                 }
               }
             }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Every time the dashmate role runs on an evonode, it causes the entire stack to restart because of a perceived change in the config file, when in fact it was the value of `platform.dapi.envoy.ssl.providerConfigs.zerossl.id` would flap between the value of `null` rendered by the `config.json` template, and the actual value rendered by the zerossl subrole.

```
TASK [dashmate : Write dashmate config file] *****************************************
--- before: /home/dashmate/.dashmate/config.json
+++ after: /home/strophy/.ansible/tmp/ansible-local-86335kydorlzs/tmpq87_w11n/dashmate.json.j2
@@ -112,7 +112,7 @@
               "providerConfigs": {
                 "zerossl": {
                   "apiKey": "f5389f3dc2074934081cf6b319552993",
-                  "id": "f0c91347940e73f1809f85c720231364"
+                  "id": null
                 }
               }
             }
```

## What was done?
<!--- Describe your changes in detail -->
- Get the existing value and include it when templating runs
- Don't set unnecessarily set value again when zerossl subrole runs if existing ID matches what is stored in SSM

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
On testnet EN-17

## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->
None

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [x] I have assigned this pull request to a milestone
