### PR TITLE
chore: speedup address import

### DIFF
--- a/ansible/roles/mn_init/tasks/main.yml
+++ b/ansible/roles/mn_init/tasks/main.yml
@@ -35,42 +35,65 @@
   until: mnsync_status.stdout | from_json | json_query('IsSynced') == true
   changed_when: mnsync_status.stdout | from_json | json_query('IsSynced') == true
 
-# - name: Initialize array for owner addresses to be imported
-#   ansible.builtin.set_fact:
-#     owner_addresses: []
+- name: Initialize array for unimported owner addresses
+  ansible.builtin.set_fact:
+    unimported_owner_addresses: []
 
-# - name: Get list of owner addresses that should be in wallet
-#   ansible.builtin.set_fact:
-#     owner_addresses: ' {{ owner_addresses + [item] }}'
-#   with_items: '{{ mnlist }}'
+- name: Get list of info on owner addresses to be imported
+  ansible.builtin.command:
+    cmd: 'dash-cli -rpcwallet={{ wallet_rpc_wallet_mno }} getaddressinfo {{ mnlist[item].owner.address }}'
+  with_items: '{{ mnlist }}'
+  register: owner_address_info
 
-# - name: Get list of addresses already imported to wallet
-#   ansible.builtin.command: dash-cli -rpcwallet={{ wallet_rpc_wallet_mno }} listaddressbalances
-#   register: address_balances
+- name: Add unimported owner addresses to list
+  ansible.builtin.set_fact:
+    unimported_owner_addresses: '{{ unimported_owner_addresses + [item.item] }}'
+  when: item.stdout | from_json | json_query("ismine") == false
+  with_items: '{{ owner_address_info.results }}'
 
-# - name: Register list of addresses
-#   set_fact:
-#     wallet_addresses: '{{ (address_balances.stdout | from_json).keys() | list }}'
+- name: Unimported owner addresses list
+  ansible.builtin.debug:
+    var: unimported_owner_addresses
 
+- name: Initialize array for unimported collateral addresses
+  ansible.builtin.set_fact:
+    unimported_collateral_addresses: []
+
+- name: Get list of info on collateral addresses to be imported
+  ansible.builtin.command:
+    cmd: 'dash-cli -rpcwallet={{ wallet_rpc_wallet_mno }} getaddressinfo {{ mnlist[item].collateral.address }}'
+  with_items: '{{ mnlist }}'
+  register: collateral_address_info
+
+- name: Add unimported collateral addresses to list
+  ansible.builtin.set_fact:
+    unimported_collateral_addresses: '{{ unimported_collateral_addresses + [item.item] }}'
+  when: item.stdout | from_json | json_query("ismine") == false
+  with_items: '{{ collateral_address_info.results }}'
+
+- name: Unimported collateral addresses list
+  ansible.builtin.debug:
+    var: unimported_collateral_addresses
 
 - name: Import masternode owner private key
   ansible.builtin.command:
     cmd: 'dash-cli -rpcwallet={{ wallet_rpc_wallet_mno }} importprivkey {{ mnlist[item].owner.private_key }} "" false'
-  with_items: '{{ mnlist }}'
-  register: result
-  changed_when: result.rc == 0
+  with_items: '{{ unimported_owner_addresses }}'
+  register: owner_import_result
+  changed_when: owner_import_result.rc == 0
 
 - name: Import masternode collateral private keys
   ansible.builtin.command:
     cmd: 'dash-cli -rpcwallet={{ wallet_rpc_wallet_mno }} importprivkey {{ mnlist[item].collateral.private_key }} "" false'
-  with_items: '{{ mnlist }}'
-  register: result
-  changed_when: result.rc == 0
+  with_items: '{{ unimported_collateral_addresses }}'
+  register: collateral_import_result
+  changed_when: collateral_import_result.rc == 0
 
 - name: Rescan blockchain
   ansible.builtin.command: 'dash-cli -rpcwallet={{ wallet_rpc_wallet_mno }} rescanblockchain'
-  register: result
-  changed_when: result.stdout | to_json | json_query('stop_height') | int > 1
+  register: rescan_result
+  when: owner_import_result.changed or collateral_import_result.changed
+  changed_when: rescan_result.stdout | to_json | json_query('stop_height') | int > 1
 
 - name: Get list of ProTx transactions from the wallet
   ansible.builtin.command:

--- a/ansible/roles/mn_init/tasks/main.yml
+++ b/ansible/roles/mn_init/tasks/main.yml
@@ -35,7 +35,24 @@
   until: mnsync_status.stdout | from_json | json_query('IsSynced') == true
   changed_when: mnsync_status.stdout | from_json | json_query('IsSynced') == true
 
-# Make this more idempotent with `getaddressinfo`
+# - name: Initialize array for owner addresses to be imported
+#   ansible.builtin.set_fact:
+#     owner_addresses: []
+
+# - name: Get list of owner addresses that should be in wallet
+#   ansible.builtin.set_fact:
+#     owner_addresses: ' {{ owner_addresses + [item] }}'
+#   with_items: '{{ mnlist }}'
+
+# - name: Get list of addresses already imported to wallet
+#   ansible.builtin.command: dash-cli -rpcwallet={{ wallet_rpc_wallet_mno }} listaddressbalances
+#   register: address_balances
+
+# - name: Register list of addresses
+#   set_fact:
+#     wallet_addresses: '{{ (address_balances.stdout | from_json).keys() | list }}'
+
+
 - name: Import masternode owner private key
   ansible.builtin.command:
     cmd: 'dash-cli -rpcwallet={{ wallet_rpc_wallet_mno }} importprivkey {{ mnlist[item].owner.private_key }} "" false'

--- a/ansible/roles/mn_init/tasks/main.yml
+++ b/ansible/roles/mn_init/tasks/main.yml
@@ -49,7 +49,7 @@
 - name: Add unimported owner addresses to list
   ansible.builtin.set_fact:
     unimported_owner_addresses: '{{ unimported_owner_addresses + [item.item] }}'
-  when: item.stdout | from_json | not json_query("ismine")
+  when: not (item.stdout | from_json | json_query("ismine"))
   with_items: '{{ owner_address_info.results }}'
 
 - name: Unimported owner addresses list
@@ -70,7 +70,7 @@
 - name: Add unimported collateral addresses to list
   ansible.builtin.set_fact:
     unimported_collateral_addresses: '{{ unimported_collateral_addresses + [item.item] }}'
-  when: item.stdout | from_json | not json_query("ismine")
+  when: not (item.stdout | from_json | json_query("ismine"))
   with_items: '{{ collateral_address_info.results }}'
 
 - name: Unimported collateral addresses list

--- a/ansible/roles/mn_init/tasks/main.yml
+++ b/ansible/roles/mn_init/tasks/main.yml
@@ -44,11 +44,12 @@
     cmd: 'dash-cli -rpcwallet={{ wallet_rpc_wallet_mno }} getaddressinfo {{ mnlist[item].owner.address }}'
   with_items: '{{ mnlist }}'
   register: owner_address_info
+  changed_when: owner_address_info.rc == 0
 
 - name: Add unimported owner addresses to list
   ansible.builtin.set_fact:
     unimported_owner_addresses: '{{ unimported_owner_addresses + [item.item] }}'
-  when: item.stdout | from_json | json_query("ismine") == false
+  when: item.stdout | from_json | not json_query("ismine")
   with_items: '{{ owner_address_info.results }}'
 
 - name: Unimported owner addresses list
@@ -64,11 +65,12 @@
     cmd: 'dash-cli -rpcwallet={{ wallet_rpc_wallet_mno }} getaddressinfo {{ mnlist[item].collateral.address }}'
   with_items: '{{ mnlist }}'
   register: collateral_address_info
+  changed_when: collateral_address_info.rc == 0
 
 - name: Add unimported collateral addresses to list
   ansible.builtin.set_fact:
     unimported_collateral_addresses: '{{ unimported_collateral_addresses + [item.item] }}'
-  when: item.stdout | from_json | json_query("ismine") == false
+  when: item.stdout | from_json | not json_query("ismine")
   with_items: '{{ collateral_address_info.results }}'
 
 - name: Unimported collateral addresses list
@@ -92,7 +94,7 @@
 - name: Rescan blockchain
   ansible.builtin.command: 'dash-cli -rpcwallet={{ wallet_rpc_wallet_mno }} rescanblockchain'
   register: rescan_result
-  when: owner_import_result.changed or collateral_import_result.changed
+  when: owner_import_result.changed or collateral_import_result.changed  # noqa: no-handler
   changed_when: rescan_result.stdout | to_json | json_query('stop_height') | int > 1
 
 - name: Get list of ProTx transactions from the wallet


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Waiting for a rescan of the entire wallet each time nodes needed unbanning was tedious and usually unnecessary in the first place.

## What was done?
<!--- Describe your changes in detail -->
We now check if the addresses we are about to import are already imported before importing them. This still takes the amount of time needed to `mn_count * 2` RPC commands, but we can skip the subsequent rescan step, saving a bit of time on testnet unban procedures.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
On testnet 

## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->
None

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [x] I have assigned this pull request to a milestone
