### PR TITLE
feat(dashmate): optional initial core chain locked height

### DIFF
--- a/ansible/roles/dashmate/templates/dashmate.json.j2
+++ b/ansible/roles/dashmate/templates/dashmate.json.j2
@@ -189,8 +189,8 @@
             },
             "genesis": {
               "genesis_time": "{{ genesis_time }}",
-              "chain_id": "dash-{{ ( 'devnet-' + dash_devnet_name if dash_network == 'devnet' else dash_network ) if tenderdash_chain_id is not defined else tenderdash_chain_id }}",
-              "initial_core_chain_locked_height": {{ platform_initial_core_chain_locked_height | int }},
+              "chaπin_id": "dash-{{ ( 'devnet-' + dash_devnet_name if dash_network == 'devnet' else dash_network ) if tenderdash_chain_id is not defined else tenderdash_chain_id }}",
+              {% if initial_core_chain_locked_height is defined && initial_core_chain_locked_height != "" %}"initial_core_chain_locked_height": {{ platform_initial_core_chain_locked_height | int }},{% endif %}
               "consensus_params": {
                 "timeout": {
                   "propose": "50000000000",

--- a/ansible/roles/dashmate/templates/dashmate.json.j2
+++ b/ansible/roles/dashmate/templates/dashmate.json.j2
@@ -190,7 +190,7 @@
             "genesis": {
               "genesis_time": "{{ genesis_time }}",
               "chain_id": "dash-{{ ( 'devnet-' + dash_devnet_name if dash_network == 'devnet' else dash_network ) if tenderdash_chain_id is not defined else tenderdash_chain_id }}",
-              {% if initial_core_chain_locked_height is defined && initial_core_chain_locked_height != "" %}"initial_core_chain_locked_height": {{ platform_initial_core_chain_locked_height | int }},{% endif %}
+              {% if initial_core_chain_locked_height is defined and initial_core_chain_locked_height != "" %}"initial_core_chain_locked_height": {{ platform_initial_core_chain_locked_height | int }},{% endif %}
               "consensus_params": {
                 "timeout": {
                   "propose": "50000000000",

--- a/ansible/roles/dashmate/templates/dashmate.json.j2
+++ b/ansible/roles/dashmate/templates/dashmate.json.j2
@@ -189,7 +189,7 @@
             },
             "genesis": {
               "genesis_time": "{{ genesis_time }}",
-              "chaπin_id": "dash-{{ ( 'devnet-' + dash_devnet_name if dash_network == 'devnet' else dash_network ) if tenderdash_chain_id is not defined else tenderdash_chain_id }}",
+              "chain_id": "dash-{{ ( 'devnet-' + dash_devnet_name if dash_network == 'devnet' else dash_network ) if tenderdash_chain_id is not defined else tenderdash_chain_id }}",
               {% if initial_core_chain_locked_height is defined && initial_core_chain_locked_height != "" %}"initial_core_chain_locked_height": {{ platform_initial_core_chain_locked_height | int }},{% endif %}
               "consensus_params": {
                 "timeout": {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Drive v0.25 is starting the chain on Core v20 activation. The initial core chain locked height option is still supported overriding the behavior. 

## What was done?
<!--- Describe your changes in detail -->
- Render `initail_core_chain_locked_height` only if set

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
None

## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->
None

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [x] I have assigned this pull request to a milestone
