### PR TITLE
chore: revert replace dashmate config command with config file stat

### DIFF
--- a/ansible/roles/dashmate/tasks/build.yml
+++ b/ansible/roles/dashmate/tasks/build.yml
@@ -92,10 +92,15 @@
   when: git.changed # noqa: no-handler
   changed_when: true
 
-- name: Check if dashmate is configured
-  ansible.builtin.stat:
-    path: '{{ dashmate_config_dir }}/config.json'
+- name: Check if default config is set
+  ansible.builtin.command: "{{ dashmate_cmd }} config"
+  become: true
+  become_user: dashmate
+  args:
+    chdir: '{{ dashmate_cwd }}'
   register: dashmate_config_result
+  ignore_errors: true
+  changed_when: true
 
 - name: Enable dashmate helper build
   ansible.builtin.command: yarn dashmate config set dashmate.helper.docker.build.enabled true
@@ -105,4 +110,4 @@
   args:
     chdir: '{{ dashmate_source_dir }}'
   changed_when: build_dashmate_helper.rc == 0
-  when: dashmate_config_result.stat.exists
+  when: dashmate_config_result.rc == 0

--- a/ansible/roles/dashmate/tasks/main.yml
+++ b/ansible/roles/dashmate/tasks/main.yml
@@ -107,10 +107,15 @@
   ansible.builtin.set_fact:
     dashmate_config_version: "{{ (dashmate_version_result.stdout | split(' ') | first() | split('/'))[1] }}"
 
-- name: Check if dashmate is configured
-  ansible.builtin.stat:
-    path: '{{ dashmate_config_dir }}/config.json'
+- name: Check if default config is set
+  ansible.builtin.command: "{{ dashmate_cmd }} config"
+  become: true
+  become_user: dashmate
+  args:
+    chdir: '{{ dashmate_cwd }}'
   register: dashmate_config_result
+  ignore_errors: true
+  changed_when: true
 
 - name: Retrieve existing ZeroSSL certificate ID
   ansible.builtin.command: "{{ dashmate_cmd }} config get platform.dapi.envoy.ssl.providerConfigs.zerossl.id"
@@ -120,12 +125,12 @@
     chdir: '{{ dashmate_cwd }}'
   register: dashmate_zerossl_id_result
   changed_when: dashmate_zerossl_id_result.rc == 0
-  when: dashmate_config_result.stat.exists
+  when: dashmate_config_result.rc == 0
 
 - name: Extract ZeroSSL certificate ID
   ansible.builtin.set_fact:
     dashmate_zerossl_config_certificate_id: "{{ dashmate_zerossl_id_result.stdout }}"
-  when: dashmate_config_result.stat.exists
+  when: dashmate_config_result.rc == 0
 
 - name: Write dashmate config file
   vars:


### PR DESCRIPTION
This reverts commit 77f0b50fa9ddfd9997108dcf98dbb595ab31f9b9.

<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
`stat`ing for the file incorrectly assumed that just because the file exists, that it would contain a configred default config, or be valid syntax for the current version of dashmate

## What was done?
<!--- Describe your changes in detail -->
Replace `stat` with `dashmate config`, which will error if:
- File is missing
- default config is not set
- file is invalid


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
On testnet

## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->
None

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [x] I have assigned this pull request to a milestone
