### PR TITLE
fix: initial_core_chain_locked_height missing even if defined

### DIFF
--- a/ansible/roles/dashmate/templates/dashmate.json.j2
+++ b/ansible/roles/dashmate/templates/dashmate.json.j2
@@ -190,7 +190,7 @@
             "genesis": {
               "genesis_time": "{{ genesis_time }}",
               "chain_id": "dash-{{ ( 'devnet-' + dash_devnet_name if dash_network == 'devnet' else dash_network ) if tenderdash_chain_id is not defined else tenderdash_chain_id }}",
-              {% if initial_core_chain_locked_height is defined and initial_core_chain_locked_height != "" %}"initial_core_chain_locked_height": {{ platform_initial_core_chain_locked_height | int }},{% endif %}
+              {% if platform_initial_core_chain_locked_height is defined and platform_initial_core_chain_locked_height != "" %}"initial_core_chain_locked_height": {{ platform_initial_core_chain_locked_height | int }},{% endif %}
               "consensus_params": {
                 "timeout": {
                   "propose": "50000000000",

--- a/ansible/roles/dashmate/templates/dashmate.json.j2
+++ b/ansible/roles/dashmate/templates/dashmate.json.j2
@@ -190,7 +190,8 @@
             "genesis": {
               "genesis_time": "{{ genesis_time }}",
               "chain_id": "dash-{{ ( 'devnet-' + dash_devnet_name if dash_network == 'devnet' else dash_network ) if tenderdash_chain_id is not defined else tenderdash_chain_id }}",
-              {% if platform_initial_core_chain_locked_height is defined and platform_initial_core_chain_locked_height != "" %}"initial_core_chain_locked_height": {{ platform_initial_core_chain_locked_height | int }},{% endif %}
+              {%+ if platform_initial_core_chain_locked_height is defined and platform_initial_core_chain_locked_height != "" %}"initial_core_chain_locked_height": {{ platform_initial_core_chain_locked_height | int }},
+              {% endif %}
               "consensus_params": {
                 "timeout": {
                   "propose": "50000000000",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
We were checking `initial_core_chain_locked_height` instead of `platform_initial_core_chain_locked_height` when conditionally templating the start height into `genesis.json`

## What was done?
<!--- Describe your changes in detail -->
Check `platform_initial_core_chain_locked_height` since we use this prefix for the var in deploy tool config

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
On testnet

## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->
None

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [x] I have assigned this pull request to a milestone
