### PR TITLE
refactor: remove `isseednode`

### DIFF
--- a/ansible/group_vars/all
+++ b/ansible/group_vars/all
@@ -99,9 +99,6 @@ dashd_minimumdifficultyblocks: 4032
 # dashd_sporkaddr:
 # dashd_sporkkey:
 
-# You can provide your own seed node in network config. May be useful if you want to connect to another network
-dashd_seednode: '{{ hostvars[groups.seed_nodes[0]]["public_ip"] if groups.seed_nodes else none }}'
-
 # Faucet stuff
 
 wallet_rpc_host: '{{ hostvars[groups.wallet_nodes[0]]["private_ip"] }}'

--- a/ansible/roles/dashd/defaults/main.yml
+++ b/ansible/roles/dashd/defaults/main.yml
@@ -7,7 +7,6 @@ dashd_zmq: false
 
 dashd_listen: false
 dashd_externalip: '{{ public_ip }}'
-dashd_isseednode: '{{ dashd_externalip == dashd_seednode }}'
 
 dashd_private_net_prefix: 16
 dashd_private_cidr: '{{ private_ip | ansible.utils.ipsubnet(dashd_private_net_prefix) }}'

--- a/ansible/roles/dashd/templates/dash.conf.j2
+++ b/ansible/roles/dashd/templates/dash.conf.j2
@@ -114,6 +114,6 @@ bind=0.0.0.0
 
 port={{ dashd_port }}
 
-{% if dashd_seednode is not none and not dashd_isseednode %}
+{% if dashd_seednode is not none %}
 addnode={{ dashd_seednode }}:{{ dashd_port }}
 {% endif %}

--- a/ansible/roles/dashd/templates/dash.conf.j2
+++ b/ansible/roles/dashd/templates/dash.conf.j2
@@ -114,6 +114,6 @@ bind=0.0.0.0
 
 port={{ dashd_port }}
 
-{% if dashd_seednode is not none %}
-addnode={{ dashd_seednode }}:{{ dashd_port }}
+{% if groups.seed_nodes is not none %}
+addnode={{ hostvars[groups.seed_nodes[(inventory_hostname | regex_replace('[^0-9]','') | int ) % (groups['seed_nodes'] | length)]]["public_ip"] }}:{{ dashd_port }}
 {% endif %}

--- a/ansible/roles/dashd/templates/dash.conf.j2
+++ b/ansible/roles/dashd/templates/dash.conf.j2
@@ -114,6 +114,6 @@ bind=0.0.0.0
 
 port={{ dashd_port }}
 
-{% if groups.seed_nodes is not none %}
-addnode={{ hostvars[groups.seed_nodes[(inventory_hostname | regex_replace('[^0-9]','') | int ) % (groups['seed_nodes'] | length)]]["public_ip"] }}:{{ dashd_port }}
-{% endif %}
+{% for seed_node in groups.seed_nodes %}
+addnode={{ hostvars[seed_node]["public_ip"] }}:{{ dashd_port }}
+{% endfor %}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
`isseednode` no longer served any purpose, because seed nodes are configured by dashmate. Additionally, all non-seed nodes were pointing at the same seed node (always `seed-1`). 

## What was done?
<!--- Describe your changes in detail -->
- Remove `isseednode`
- Target seed nodes evenly when templating dash.conf

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
On testnet

## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->
None

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [x] I have assigned this pull request to a milestone
