### PR TITLE
fix: Error: Timeout of 20000ms exceeded

### DIFF
--- a/test/smoke/drive.js
+++ b/test/smoke/drive.js
@@ -18,7 +18,7 @@ describe('Drive', () => {
 
       const statusPromises = dashmateHosts.map(async (hostName) => {
         const docker = createDocker(`http://${inventory.meta.hostvars[hostName].public_ip}`, {
-          timeout: this.timeout() - 1000,
+          timeout: this.timeout() - 5000,
         });
 
         let containerId;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Drive smoke tests were failing on all nodes with:
```
  1) Smoke
       Drive
         HP masternodes
           "before all" hook: Collect echo info from Drive in "HP masternodes":
     Error: Timeout of 20000ms exceeded. For async tests and hooks, ensure "done()" is called; if returning a Promise, ensure it resolves. (/home/strophy/Code/dashpay/dash-network-deploy/test/smoke/index.spec.js)
      at listOnTimeout (node:internal/timers:569:17)
      at process.processTimers (node:internal/timers:512:7)
```

## What was done?
<!--- Describe your changes in detail -->
I noticed that the Tenderdash tests run the exact same command, but were not failing as a whole. Adjusting the timeout to match the value in the Tenderdash tests resolves the issue for me. I don't know why this works, but it does.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Against testnet

## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->
None

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [x] I have assigned this pull request to a milestone
