### PR TITLE
fix(dashmate): switch back to outdated certificate on deploy

### DIFF
--- a/ansible/roles/dashmate/tasks/main.yml
+++ b/ansible/roles/dashmate/tasks/main.yml
@@ -117,7 +117,7 @@
   ignore_errors: true
   changed_when: true
 
-- name: Retrieve existing ZeroSSL certificate ID
+- name: Get ZeroSSL certificate ID from config
   ansible.builtin.command: "{{ dashmate_cmd }} config get platform.dapi.envoy.ssl.providerConfigs.zerossl.id"
   become: true
   become_user: dashmate
@@ -127,10 +127,10 @@
   changed_when: dashmate_zerossl_id_result.rc == 0
   when: dashmate_config_result.rc == 0
 
-- name: Extract ZeroSSL certificate ID
+- name: Set ZeroSSL certificate ID from config
   ansible.builtin.set_fact:
     dashmate_zerossl_config_certificate_id: "{{ dashmate_zerossl_id_result.stdout }}"
-  when: dashmate_config_result.rc == 0
+  when: dashmate_config_result.rc == 0 and dashmate_zerossl_id_result.stdout != 'null'
 
 - name: Write dashmate config file
   vars:

--- a/ansible/roles/dashmate/tasks/ssl/zerossl.yml
+++ b/ansible/roles/dashmate/tasks/ssl/zerossl.yml
@@ -25,7 +25,7 @@
   ansible.builtin.set_fact:
     dashmate_zerossl_ssm_certificate_id: "{{ lookup('aws_ssm', '{{ dashmate_zerossl_ssm_path }}-id', on_missing='skip') }}"
 
-- name: Set ZeroSSL certificate ID to dashmate config from SSM
+- name: Set ZeroSSL certificate ID to dashmate config from SSM if not set
   ansible.builtin.command: "{{ dashmate_cmd }} config set {{ dashmate_zerossl_config_path }}.id {{ dashmate_zerossl_ssm_certificate_id }}"
   become: true
   become_user: dashmate
@@ -35,7 +35,7 @@
   changed_when: dashmate_zerossl_id.rc == 0
   when:
     - dashmate_zerossl_ssm_certificate_id != ''
-    - dashmate_zerossl_ssm_certificate_id != dashmate_zerossl_config_certificate_id
+    - dashmate_zerossl_config_certificate_id is not defined
 
 # Copy ZeroSSL files if they are not present
 
@@ -88,27 +88,32 @@
     chdir: '{{ dashmate_cwd }}'
   register: dashmate_zerossl_id
   changed_when: dashmate_zerossl_id.rc == 0
-  when: dashmate_zerossl_ssm_certificate_id == ''
+  when: dashmate_obtain is defined and dashmate_obtain.changed
 
-- name: Update ZeroSSL certificate ID in AWS SSM parameter store
+- name: Set new ZeroSSL certificate ID from config
+  ansible.builtin.set_fact:
+    dashmate_zerossl_config_certificate_id: "{{ dashmate_zerossl_id.stdout }}"
+  when: dashmate_obtain is defined and dashmate_obtain.changed
+
+- name: Update ZeroSSL certificate ID in AWS SSM parameter store if changed
   delegate_to: localhost
   become: false
   community.aws.ssm_parameter:
     name: '{{ dashmate_zerossl_ssm_path }}-id'
     value: '{{ dashmate_zerossl_id.stdout }}'
-  when: dashmate_zerossl_ssm_certificate_id == ''
+  when: dashmate_zerossl_ssm_certificate_id != dashmate_zerossl_config_certificate_id
 
 - name: Read new generated ZeroSSL private key file to variable
   ansible.builtin.slurp:
     src: '{{ dashmate_zerossl_keys_path }}/{{ dashmate_zerossl_private_key_file_name }}'
   register: dashmate_zerossl_private_key_file
-  when: dashmate_zerossl_ssm_certificate_id == ''
+  when: dashmate_zerossl_ssm_certificate_id != dashmate_zerossl_config_certificate_id
 
 - name: Read new generated ZeroSSL CSR file to variable
   ansible.builtin.slurp:
     src: '{{ dashmate_zerossl_keys_path }}/{{ dashmate_zerossl_csr_file_name }}'
   register: dashmate_zerossl_csr_file
-  when: dashmate_zerossl_ssm_certificate_id == ''
+  when: dashmate_zerossl_ssm_certificate_id != dashmate_zerossl_config_certificate_id
 
 - name: Set new generated ZeroSSL CSR and private key files
   ansible.builtin.set_fact:
@@ -117,7 +122,7 @@
         content: '{{ dashmate_zerossl_private_key_file.content | b64decode }}'
       - name: "{{ dashmate_zerossl_csr_file_name }}"
         content: '{{ dashmate_zerossl_csr_file.content | b64decode }}'
-  when: dashmate_zerossl_ssm_certificate_id == ''
+  when: dashmate_zerossl_ssm_certificate_id != dashmate_zerossl_config_certificate_id
 
 - name: Update ZeroSSL private key and CSR files in AWS SSM parameter store
   delegate_to: localhost
@@ -126,4 +131,4 @@
     name: '{{ dashmate_zerossl_ssm_path }}-{{ item.name }}'
     value: '{{ item.content }}'
   loop: '{{ dashmate_zerossl_files }}'
-  when: dashmate_zerossl_ssm_certificate_id == ''
+  when: dashmate_zerossl_ssm_certificate_id != dashmate_zerossl_config_certificate_id

--- a/ansible/roles/dashmate/tasks/ssl/zerossl.yml
+++ b/ansible/roles/dashmate/tasks/ssl/zerossl.yml
@@ -100,7 +100,7 @@
   become: false
   community.aws.ssm_parameter:
     name: '{{ dashmate_zerossl_ssm_path }}-id'
-    value: '{{ dashmate_zerossl_id.stdout }}'
+    value: '{{ dashmate_zerossl_config_certificate_id }}'
   when: dashmate_zerossl_ssm_certificate_id != dashmate_zerossl_config_certificate_id
 
 - name: Read new generated ZeroSSL private key file to variable

--- a/ansible/roles/dashmate/tasks/ssl/zerossl.yml
+++ b/ansible/roles/dashmate/tasks/ssl/zerossl.yml
@@ -95,7 +95,7 @@
     dashmate_zerossl_config_certificate_id: "{{ dashmate_zerossl_id.stdout }}"
   when: dashmate_obtain is defined and dashmate_obtain.changed
 
-- name: Update ZeroSSL certificate ID in AWS SSM parameter store if changed
+- name: Update ZeroSSL certificate ID in AWS SSM parameter store
   delegate_to: localhost
   become: false
   community.aws.ssm_parameter:

--- a/ansible/roles/dashmate/templates/dashmate.json.j2
+++ b/ansible/roles/dashmate/templates/dashmate.json.j2
@@ -104,7 +104,7 @@
               "providerConfigs": {
                 "zerossl": {
                   "apiKey": {% if dashmate_platform_dapi_envoy_ssl_provider_config_zerossl_api_key is not none and dashmate_platform_dapi_envoy_ssl_provider_config_zerossl_api_key != '' %}"{{ dashmate_platform_dapi_envoy_ssl_provider_config_zerossl_api_key }}"{% else %}null{% endif %},
-                  "id": {% if dashmate_zerossl_config_certificate_id is defined and dashmate_zerossl_config_certificate_id != 'null' %}"{{ dashmate_zerossl_config_certificate_id }}"{% else %}null{% endif +%}
+                  "id": {% if dashmate_zerossl_config_certificate_id is defined %}"{{ dashmate_zerossl_config_certificate_id }}"{% else %}null{% endif +%}
                 }
               }
             }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
During deploy, if certificate was changed in dashmate config, instead of updating SSM we rewrite config back to old value from SSM. It prevents dashmate helper to update certificates automatically.

## What was done?
<!--- Describe your changes in detail -->
- Write ID from SSM to config only if the value in config is null. We do not overwrite new certificate, created with the dashmate helper or the obtain command.
- Update SSM when ID from config and SSM are different. It means certificate was updated with the dashmate helper or the obtain command.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
None

## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->
None

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [x] I have assigned this pull request to a milestone
