### PR TITLE
chore: replace cloudwatch mon script with cloudwatch agent

### DIFF
--- a/ansible/deploy.yml
+++ b/ansible/deploy.yml
@@ -61,14 +61,7 @@
           - ubuntu
     - docker_options
     - eternal_terminal
-
-- name: Install AWS monitoring scripts
-  hosts: all
-  become: true
-  roles:
-    - role: Restless-ET.aws-scripts-mon
-      aws_scripts_mon_options: "--mem-util --disk-space-util --disk-path=/ --swap-util"
-      aws_scripts_mon_use_iam: true
+    - christiangda.amazon_cloudwatch_agent
 
 - name: Configure tcpdump
   hosts: all

--- a/ansible/requirements.yml
+++ b/ansible/requirements.yml
@@ -23,6 +23,9 @@ roles:
   - src: arillso.logrotate
     version: 1.6.1
 
+  - src: christiangda.amazon_cloudwatch_agent
+    version: 2.1.2
+
   - src: geerlingguy.docker
     version: 6.1.0
 
@@ -37,6 +40,3 @@ roles:
 
   - src: kyl191.openvpn
     version: v0.9.1
-
-  - src: Restless-ET.aws-scripts-mon
-    version: 1.0.1


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
We have been using the Cloudwatch monitoring scripts written in Perl to send data from instances to Cloudwatch. These scripts seem to have been deprecated sometime in 2020, and should be replaced with Cloudwatch Agent.

## What was done?
<!--- Describe your changes in detail -->
Replace unmaintained `aws-scripts-mon` Ansible role with maintained `christiangda.amazon_cloudwatch_agent`.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested on testnet `masternode-1`

## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->
crontab for `ubuntu` user needs to be cleared and the `/opt/aws-scripts-mon` directory deleted on all nodes to avoid delivering metrics twice. I'll take this step when merging the PR, after verifying metrics are being delivered properly.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [x] I have assigned this pull request to a milestone
