### PR TITLE
fix: use tenderdash instead of drive var

### DIFF
--- a/ansible/roles/elastic_beats/vars/platform.yml
+++ b/ansible/roles/elastic_beats/vars/platform.yml
@@ -2,7 +2,7 @@
 
 filebeat_platform_inputs:
   - type: log
-    enabled: "{{ drive_host_info.containers | length > 0 }}"
+    enabled: "{{ tenderdash_host_info.containers | length > 0 }}"
     json.message_key: message
     exclude_files: ['\.gz$']
     index: "logs-drive.abci-{{ dash_network_name }}-%{[agent.version]}"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
drive_host_info var no longer exists


## What was done?
Use tenderdash_host_info instead


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone
