### PR TITLE
chore: update filebeat templates to support drive from file and tenderdash only on logs nodes

### DIFF
--- a/ansible/roles/elastic_beats/tasks/main.yml
+++ b/ansible/roles/elastic_beats/tasks/main.yml
@@ -14,7 +14,14 @@
       name: tender
   register: tenderdash_host_info
 
-- name: Set container ids
+- name: Get drive container host info
+  community.docker.docker_host_info:
+    containers: true
+    containers_filters:
+      name: abci
+  register: drive_host_info
+
+- name: Set container ids for core and tenderdash
   ansible.builtin.set_fact:
     core_container_id: '{{ core_host_info.containers[0].Id if (core_host_info.containers | length > 0) else "null" }}'
     tenderdash_container_id: '{{ tenderdash_host_info.containers[0].Id if (tenderdash_host_info.containers | length > 0) else "null" }}'
@@ -27,16 +34,25 @@
   ansible.builtin.include_vars:
     file: core.yml
 
-- name: Load platform input config
+- name: Load tenderdash input config
   ansible.builtin.include_vars:
-    file: platform.yml
-  # We make sure that we running it on a node with platform started
+    file: tenderdash.yml
   when: tenderdash_host_info.containers | length > 0
 
-- name: Merge input configs
+- name: Load drive input config
+  ansible.builtin.include_vars:
+    file: drive.yml
+  when: drive_host_info.containers | length > 0
+
+- name: Merge drive and tenderdash input configs
   ansible.builtin.set_fact:
-    filebeat_inputs: "{{ [filebeat_inputs, filebeat_platform_inputs] | community.general.lists_mergeby('index') }}"
-  when: filebeat_platform_inputs is defined
+    platform_filebeat_inputs: "{{ [platform_filebeat_inputs, drive_filebeat_inputs] | community.general.lists_mergeby('index') }}"
+  when: platform_filebeat_inputs is defined and drive_filebeat_inputs is defined
+
+- name: Merge platform and core input configs
+  ansible.builtin.set_fact:
+    filebeat_inputs: "{{ [filebeat_inputs, platform_filebeat_inputs] | community.general.lists_mergeby('index') }}"
+  when: platform_filebeat_inputs is defined
 
 - name: Set up filebeat log monitoring
   ansible.builtin.include_role:

--- a/ansible/roles/elastic_beats/vars/drive.yml
+++ b/ansible/roles/elastic_beats/vars/drive.yml
@@ -1,6 +1,6 @@
 ---
 
-filebeat_platform_inputs:
+drive_filebeat_inputs:
   - type: log
     enabled: "{{ drive_host_info.containers | length > 0 }}"
     json.message_key: message
@@ -25,24 +25,3 @@ filebeat_platform_inputs:
               to: "log.level"
           ignore_missing: true
           fail_on_error: true
-  - type: container
-    enabled: "{{ tenderdash_host_info.containers | length > 0 }}"
-    json.message_key: message
-    index: "logs-drive.tenderdash-{{ dash_network_name }}-%{[agent.version]}"
-    paths:
-      - '/var/lib/docker/containers/{{ tenderdash_container_id }}/*.log'
-    processors:
-      - add_fields:
-          target: event
-          fields:
-            dataset: "drive.tenderdash-{{ dash_network_name }}"
-      - rename:
-          fields:
-            - from: "json.message"
-              to: "message"
-          ignore_missing: true
-          fail_on_error: true
-      - rename:
-          fields:
-            - from: "json.level"
-              to: "log.level"

--- a/ansible/roles/elastic_beats/vars/platform.yml
+++ b/ansible/roles/elastic_beats/vars/platform.yml
@@ -25,13 +25,12 @@ filebeat_platform_inputs:
               to: "log.level"
           ignore_missing: true
           fail_on_error: true
-  - type: log
+  - type: container
     enabled: "{{ tenderdash_host_info.containers | length > 0 }}"
     json.message_key: message
-    exclude_files: ['\.gz$']
     index: "logs-drive.tenderdash-{{ dash_network_name }}-%{[agent.version]}"
     paths:
-      - "{{ abci_logs_path }}/tenderdash.log*"
+      - '/var/lib/docker/containers/{{ tenderdash_container_id }}/*.log'
     processors:
       - add_fields:
           target: event

--- a/ansible/roles/elastic_beats/vars/tenderdash.yml
+++ b/ansible/roles/elastic_beats/vars/tenderdash.yml
@@ -1,0 +1,24 @@
+---
+
+platform_filebeat_inputs:
+  - type: container
+    enabled: "{{ tenderdash_host_info.containers | length > 0 }}"
+    json.message_key: message
+    index: "logs-drive.tenderdash-{{ dash_network_name }}-%{[agent.version]}"
+    paths:
+      - '/var/lib/docker/containers/{{ tenderdash_container_id }}/*.log'
+    processors:
+      - add_fields:
+          target: event
+          fields:
+            dataset: "drive.tenderdash-{{ dash_network_name }}"
+      - rename:
+          fields:
+            - from: "json.message"
+              to: "message"
+          ignore_missing: true
+          fail_on_error: true
+      - rename:
+          fields:
+            - from: "json.level"
+              to: "log.level"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Filebeat needs to support the following new configs:
- Reading drive logs from `drive-json.log` on dashmate-managed evonodes
- Reading tenderdash logs from both evonodes and seed nodes

## What was done?
<!--- Describe your changes in detail -->
- Split platform logs rules into separate files and update template merge logic
- Read tenderdash logs from Docker because `tenderdash.log` is not available on seed nodes

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
On testnet hp-masternode-10

## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->
None

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [x] I have assigned this pull request to a milestone
