### PR TITLE
chore: make monitoring config more granular

### DIFF
--- a/terraform/aws/monitoring.tf
+++ b/terraform/aws/monitoring.tf
@@ -29,7 +29,7 @@ locals {
 
 resource "aws_cloudwatch_metric_alarm" "cpu_monitoring" {
 
-  count = var.monitoring_enabled ? length(local.instance_ids) : 0
+  count = var.monitoring_cpu_enabled ? length(local.instance_ids) : 0
 
   alarm_name          = "${terraform.workspace}-${local.instance_hostnames[count.index]}-cpu-monitoring"
   comparison_operator = "GreaterThanOrEqualToThreshold"
@@ -53,7 +53,7 @@ resource "aws_cloudwatch_metric_alarm" "cpu_monitoring" {
 
 resource "aws_cloudwatch_metric_alarm" "memory_monitoring" {
 
-  count = var.monitoring_enabled ? length(local.instance_ids) : 0
+  count = var.monitoring_mem_enabled ? length(local.instance_ids) : 0
 
   alarm_name          = "${terraform.workspace}-${local.instance_hostnames[count.index]}-memory-monitoring"
   comparison_operator = "GreaterThanOrEqualToThreshold"
@@ -77,7 +77,7 @@ resource "aws_cloudwatch_metric_alarm" "memory_monitoring" {
 
 resource "aws_cloudwatch_metric_alarm" "swap_monitoring" {
 
-  count = var.monitoring_enabled ? length(local.instance_ids) : 0
+  count = var.monitoring_swap_enabled ? length(local.instance_ids) : 0
 
   alarm_name          = "${terraform.workspace}-${local.instance_hostnames[count.index]}-swap-monitoring"
   comparison_operator = "GreaterThanOrEqualToThreshold"
@@ -101,7 +101,7 @@ resource "aws_cloudwatch_metric_alarm" "swap_monitoring" {
 
 resource "aws_cloudwatch_metric_alarm" "diskspace_monitoring" {
 
-  count = var.monitoring_enabled ? length(local.instance_ids) : 0
+  count = var.monitoring_disk_enabled ? length(local.instance_ids) : 0
 
   alarm_name          = "${terraform.workspace}-${local.instance_hostnames[count.index]}-diskspace-monitoring"
   comparison_operator = "GreaterThanOrEqualToThreshold"

--- a/terraform/aws/monitoring.tf
+++ b/terraform/aws/monitoring.tf
@@ -48,7 +48,7 @@ resource "aws_cloudwatch_metric_alarm" "cpu_monitoring" {
     InstanceId = local.instance_ids[count.index]
   }
 
-  alarm_description = "This metric monitors ec2 cpu utilization"
+  alarm_description = "This alarm monitors ec2 cpu utilization"
 }
 
 resource "aws_cloudwatch_metric_alarm" "memory_monitoring" {
@@ -72,7 +72,7 @@ resource "aws_cloudwatch_metric_alarm" "memory_monitoring" {
     InstanceId = local.instance_ids[count.index]
   }
 
-  alarm_description = "This metric monitors ec2 memory utilization"
+  alarm_description = "This alarm monitors ec2 memory utilization"
 }
 
 resource "aws_cloudwatch_metric_alarm" "swap_monitoring" {
@@ -96,7 +96,7 @@ resource "aws_cloudwatch_metric_alarm" "swap_monitoring" {
     InstanceId = local.instance_ids[count.index]
   }
 
-  alarm_description = "This metric monitors ec2 swap utilization"
+  alarm_description = "This alarm monitors ec2 swap utilization"
 }
 
 resource "aws_cloudwatch_metric_alarm" "diskspace_monitoring" {
@@ -122,5 +122,5 @@ resource "aws_cloudwatch_metric_alarm" "diskspace_monitoring" {
     Filesystem = "/dev/nvme0n1p1"
   }
 
-  alarm_description = "This metric monitors ec2 disk utilization"
+  alarm_description = "This alarm monitors ec2 disk utilization"
 }

--- a/terraform/aws/variables.tf
+++ b/terraform/aws/variables.tf
@@ -161,6 +161,26 @@ variable "public_network_name" {
   default     = ""
 }
 
+variable "monitoring_cpu_enabled" {
+  description = "enable monitoring with CloudWatch"
+  default     = false
+}
+
+variable "monitoring_mem_enabled" {
+  description = "enable monitoring with CloudWatch"
+  default     = false
+}
+
+variable "monitoring_swap_enabled" {
+  description = "enable monitoring with CloudWatch"
+  default     = false
+}
+
+variable "monitoring_disk_enabled" {
+  description = "enable monitoring with CloudWatch"
+  default     = false
+}
+
 variable "monitoring_enabled" {
   description = "enable monitoring with CloudWatch"
   default     = false

--- a/terraform/aws/variables.tf
+++ b/terraform/aws/variables.tf
@@ -162,22 +162,22 @@ variable "public_network_name" {
 }
 
 variable "monitoring_cpu_enabled" {
-  description = "enable monitoring with CloudWatch"
+  description = "enable CPU utilization alarm with CloudWatch"
   default     = false
 }
 
 variable "monitoring_mem_enabled" {
-  description = "enable monitoring with CloudWatch"
+  description = "enable memory used alarm with CloudWatch"
   default     = false
 }
 
 variable "monitoring_swap_enabled" {
-  description = "enable monitoring with CloudWatch"
+  description = "enable swap used alarm with CloudWatch"
   default     = false
 }
 
 variable "monitoring_disk_enabled" {
-  description = "enable monitoring with CloudWatch"
+  description = "enable disk used alarm with CloudWatch"
   default     = false
 }
 

--- a/terraform/aws/variables.tf
+++ b/terraform/aws/variables.tf
@@ -181,11 +181,6 @@ variable "monitoring_disk_enabled" {
   default     = false
 }
 
-variable "monitoring_enabled" {
-  description = "enable monitoring with CloudWatch"
-  default     = false
-}
-
 variable "core_node_disk_size" {
   description = "Default disk size for nodes, increase for testnet"
   default     = 20


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
We want to be able to selectively enable CloudWatch alarms in order to control costs.

## What was done?
<!--- Describe your changes in detail -->
Make monitoring config granular, so we can enable e.g. only disk space alarms

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Untested

## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->
None

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [x] I have assigned this pull request to a milestone
