### PR TITLE
fix: drive log specification missing grovedb ops

### DIFF
--- a/ansible/roles/dashmate/templates/dashmate.json.j2
+++ b/ansible/roles/dashmate/templates/dashmate.json.j2
@@ -153,7 +153,7 @@
               },
               "groveDbOperationsFile": {
                 "destination": "{{ dashmate_logs_dir }}/drive-grovedb-operations.log",
-                "level": "debug,tenderdash_abci=trace,drive_abci=trace,drive=trace,dpp=trace",
+                "level": "debug,tenderdash_abci=trace,drive_abci=trace,drive=trace,dpp=trace,drive_grovedb_operations=trace",
                 "format": "json",
                 "color": null
               }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Drive grove db operation log is missing actual grovedb operations

## What was done?
<!--- Describe your changes in detail -->
- Added drive grovedb operations to log specification string in dashmate config 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
None

## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->
None

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [x] I have assigned this pull request to a milestone
