### PR TITLE
chore: increase delay between submitting and voting on proposals

### DIFF
--- a/ansible/roles/generate_proposals/tasks/createproposaltx.yml
+++ b/ansible/roles/generate_proposals/tasks/createproposaltx.yml
@@ -87,4 +87,4 @@
     name: generate_blocks
   vars:
     generate: blocks
-    num_blocks: 1
+    num_blocks: 2

--- a/ansible/roles/generate_proposals/tasks/createproposaltx.yml
+++ b/ansible/roles/generate_proposals/tasks/createproposaltx.yml
@@ -88,3 +88,7 @@
   vars:
     generate: blocks
     num_blocks: 2
+
+- name: Pause for 10 seconds to allow gobjects to propagate
+  ansible.builtin.pause:
+    seconds: 10


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Proposals were successfully created but `gobject list` was empty resulting in `gobject vote-many` being skipped. Manually checking the proposal count and running the role twice resulted in successful votes, so I think we are just going too quickly here for the slowish P2P governance system.

## What was done?
<!--- Describe your changes in detail -->
Increase block delay between steps and add 10 second wait just in case

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
On `devnet-ouzo`

## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->
None

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [x] I have assigned this pull request to a milestone
