### PR TITLE
fix: *_hpmn methods are deprecated. Use the related *_evo methods

### DIFF
--- a/ansible/roles/mn_createprotx/tasks/createprovidertx.yml
+++ b/ansible/roles/mn_createprotx/tasks/createprovidertx.yml
@@ -4,7 +4,7 @@
 
 - name: Create ProTx for {{ masternode_name ~ '/' ~ masternode.owner.address }}
   ansible.builtin.command: "dash-cli -rpcwallet={{ wallet_rpc_wallet_mno }} protx
-            {% if masternode_name is match('hp*') %} register_hpmn {% else %} register {% endif %}
+            {% if masternode_name is match('hp*') %} register_evo {% else %} register {% endif %}
             {{ vars['collateral_txid_' + masternode_name | replace('-', '_')] }}
             {{ vars['collateral_vout_' + masternode_name | replace('-', '_')] }}
             {{ hostvars[masternode_name].public_ip }}:{{ dashd_port }}

--- a/ansible/roles/mn_unban/tasks/createproupservtx.yml
+++ b/ansible/roles/mn_unban/tasks/createproupservtx.yml
@@ -14,7 +14,7 @@
   when: 'masternode_name is not match ("hp*")'
 
 - name: Create HP ProUpServTx for {{ masternode_name ~ '/' ~ masternode.owner.address }}
-  ansible.builtin.command: "dash-cli -rpcwallet={{ wallet_rpc_wallet_mno }} protx update_service_hpmn
+  ansible.builtin.command: "dash-cli -rpcwallet={{ wallet_rpc_wallet_mno }} protx update_service_evo
             {{ vars['protx_' + masternode_name | replace('-', '_')] }}
             {{ hostvars[masternode_name].public_ip }}:{{ dashd_port }}
             {{ masternode.operator.private_key }}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Unban was failing with `error message: *_hpmn methods are deprecated. Use the related *_evo methods or set -deprecatedrpc=hpmn to enable them`

## What was done?
<!--- Describe your changes in detail -->
Change RPC calls to use `*_evo`

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
On testnet

## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->
None

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [x] I have assigned this pull request to a milestone
