### PR TITLE
fix: increase timeout on sendtx test

### DIFF
--- a/test/smoke/quorum.js
+++ b/test/smoke/quorum.js
@@ -217,7 +217,7 @@ describe('Quorums', () => {
     });
 
     before('Send a transaction', async () => {
-      const timeout = 15000; // set individual rpc client timeout
+      const timeout = 25000; // set individual rpc client timeout
 
       const client = createRpcClientFromConfig(inventory.wallet_nodes.hosts[0]);
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
Core v20 takes slightly longer to process a TX


## What was done?
Increase timeout


## How Has This Been Tested?
tests


## Breaking Changes
None
