### PR TITLE
feat: use new group and var to install dashd_nightly_image on subset of nodes

### DIFF
--- a/ansible/roles/dashd/tasks/main.yml
+++ b/ansible/roles/dashd/tasks/main.yml
@@ -112,6 +112,19 @@
     pull: true
     timeout: 30
 
+
+- name: Determine node-specific start day
+  set_fact:
+    node_start_day: "{{ (play_hosts.index(inventory_hostname) % nightly_masternodes) + 1 }}"
+  when: 'inventory_hostname in groups[nightly_masternodes]'
+
+- name: Schedule restart for hosts running nightly core
+  ansible.builtin.cron:
+    name: "Update nightly core container"
+    day: "{{ node_start_day }}/{{ groups['nightly_masternodes'] | length }}"
+    job: "cd {{ dashd_compose_path }} && docker-compose pull && docker compose up -d"
+  when: 'inventory_hostname in groups[nightly_masternodes]'
+
 - name: Wait for rpc to be available
   ansible.builtin.command: dash-cli getgovernanceinfo
   register: task_result

--- a/ansible/roles/dashd/templates/docker-compose.yml.j2
+++ b/ansible/roles/dashd/templates/docker-compose.yml.j2
@@ -2,7 +2,7 @@ version: '3'
 
 services:
   dashcore:
-    image: {{ dashd_image }}
+    image: "{{ dashd_nightly_image if 'nightly_masternodes' in group_names else dashd_image }}"
     user: {{ dash_user.uid }}:{{ dash_user.group }}
     container_name: dashd
     restart: always

--- a/ansible/roles/dashmate/tasks/main.yml
+++ b/ansible/roles/dashmate/tasks/main.yml
@@ -283,6 +283,19 @@
     - not dashmate_restart_all.changed
   changed_when: dashmate_force_start.rc == 0
 
+- name: Determine node-specific start day for hosts running nightly core
+  set_fact:
+    node_start_day: "{{ (play_hosts.index(inventory_hostname) % nightly_masternodes) + 1 }}"
+  when: 'inventory_hostname in groups[nightly_masternodes]'
+
+- name: Schedule restart for hosts running nightly core
+  ansible.builtin.cron:
+    name: "Update nightly core container"
+    day: "{{ node_start_day }}/{{ groups['nightly_masternodes'] | length }}"
+    job: "cd {{ dashmate_cwd }} && {{ dashmate_cmd }} update && {{ dashmate_cmd }} start --force --verbose"
+    user: "{{ dashmate_user }}"
+  when: 'inventory_hostname in groups[nightly_masternodes]'
+
 - name: Disable dashmate helper build
   ansible.builtin.command: "{{ dashmate_cmd }} config set dashmate.helper.docker.build.enabled false"
   become: true

--- a/ansible/roles/dashmate/templates/dashmate.json.j2
+++ b/ansible/roles/dashmate/templates/dashmate.json.j2
@@ -35,7 +35,7 @@
           "port": 3001
         },
         "docker": {
-          "image": "{{ dashd_image }}",
+          "image": "{{ dashd_nightly_image if 'nightly_nodes' in group_names else dashd_image }}",
           "commandArgs": []
         },
         "p2p": {

--- a/ansible/roles/dashmate/templates/dashmate.json.j2
+++ b/ansible/roles/dashmate/templates/dashmate.json.j2
@@ -35,7 +35,7 @@
           "port": 3001
         },
         "docker": {
-          "image": "{{ dashd_nightly_image if 'nightly_nodes' in group_names else dashd_image }}",
+          "image": "{{ dashd_nightly_image if 'nightly_masternodes' in group_names else dashd_image }}",
           "commandArgs": []
         },
         "p2p": {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Core team required latest-nightly images on some nodes

## What was done?
<!--- Describe your changes in detail -->
Add condition to use dashd_nightly_image on nightly_masternodes

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
On testnet

## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->
Weird new behaviour?

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [x] I have assigned this pull request to a milestone
