### PR TITLE
fix: devnet should be 8GB

### DIFF
--- a/ansible/group_vars/all
+++ b/ansible/group_vars/all
@@ -160,7 +160,7 @@ elastic_version: 8.11.3
 kibana_encryptionkey:
 # Set to 50% of instance memory
 # https://www.elastic.co/guide/en/elasticsearch/guide/current/heap-sizing.html
-elastic_heap_size: 16g
+elastic_heap_size: 8g
 
 elastic_compose_project_name: elastic
 elastic_path: '{{ dashd_home }}/{{ elastic_compose_project_name }}'


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
Devnet elastic gets overloaded with default 16GB


## What was done?
Change elastic_heap_size to 8GB so node does not crash on deployment


## How Has This Been Tested?
Deploying a devnet


## Breaking Changes
None


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone
