### PR TITLE
fix: generate regex too open

### DIFF
--- a/lib/cli/init.sh
+++ b/lib/cli/init.sh
@@ -2,7 +2,7 @@
 
 networks=("regtest testnet devnet mainnet")
 
-if grep -q "devnet" <<< "$NETWORK_NAME"; then
+if grep -q "devnet-" <<< "$NETWORK_NAME"; then
     NETWORK="devnet"
     NETWORK_DEVNET_NAME="${NETWORK_NAME:7}"
     if [ -z $NETWORK_DEVNET_NAME ]; then


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
Fixes https://github.com/dashpay/dash-network-deploy/issues/618 


## What was done?
Ensuring devnet name always has a - (devnet-foo) since deploy won't accept it othewise

## How Has This Been Tested?
Locally with /bin/generate


## Breaking Changes
None


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone
