### PR TITLE
feat: add Elasticsearch, Metricbeat, and Kibana Ansible roles

### DIFF
--- a/ansible/deploy.yml
+++ b/ansible/deploy.yml
@@ -289,3 +289,17 @@
         networks: true
         volumes: false
         builder_cache: true
+
+- name: Deploy Metricbeat to all hosts
+  hosts: all   # this needs to changes based on what we are targetting to monitor
+  become: true
+  roles:
+    - metricbeat
+
+
+- name: Set up Elasticsearch and Kibana
+  hosts: host_IP   # This needs to be changed
+  become: true
+  roles:
+    - elasticsearch
+    - kibana

--- a/ansible/deploy.yml
+++ b/ansible/deploy.yml
@@ -303,3 +303,4 @@
   roles:
     - elasticsearch
     - kibana
+    

--- a/ansible/deploy.yml
+++ b/ansible/deploy.yml
@@ -303,4 +303,3 @@
   roles:
     - elasticsearch
     - kibana
-    

--- a/ansible/roles/elasticsearch/tasks/main.yml
+++ b/ansible/roles/elasticsearch/tasks/main.yml
@@ -1,33 +1,33 @@
 ---
 - name: Import Elasticsearch GPG key
-  apt_key:
+  ansible.builtin.apt_key:
     url: https://artifacts.elastic.co/GPG-KEY-elasticsearch
     state: present
   become: true
 
 - name: Add Elasticsearch repository
-  apt_repository:
+  ansible.builtin.apt_repository:
     repo: 'deb https://artifacts.elastic.co/packages/7.x/apt stable main'
     state: present
   become: true
 
 - name: Install Elasticsearch
-  apt:
+  ansible.builtin.apt:
     name: elasticsearch
     state: present
     update_cache: yes
   become: true
 
 - name: Configure Elasticsearch
-  template:
+  ansible.builtin.template:
     src: elasticsearch.yml.j2
     dest: /etc/elasticsearch/elasticsearch.yml
   notify: Restart Elasticsearch
   become: true
 
 - name: Enable and start Elasticsearch service
-  systemd:
+  ansible.builtin.systemd:
     name: elasticsearch
-    enabled: yes
+    enabled: true
     state: started
   become: true

--- a/ansible/roles/elasticsearch/tasks/main.yml
+++ b/ansible/roles/elasticsearch/tasks/main.yml
@@ -1,0 +1,33 @@
+---
+- name: Import Elasticsearch GPG key
+  apt_key:
+    url: https://artifacts.elastic.co/GPG-KEY-elasticsearch
+    state: present
+  become: true
+
+- name: Add Elasticsearch repository
+  apt_repository:
+    repo: 'deb https://artifacts.elastic.co/packages/7.x/apt stable main'
+    state: present
+  become: true
+
+- name: Install Elasticsearch
+  apt:
+    name: elasticsearch
+    state: present
+    update_cache: yes
+  become: true
+
+- name: Configure Elasticsearch
+  template:
+    src: elasticsearch.yml.j2
+    dest: /etc/elasticsearch/elasticsearch.yml
+  notify: Restart Elasticsearch
+  become: true
+
+- name: Enable and start Elasticsearch service
+  systemd:
+    name: elasticsearch
+    enabled: yes
+    state: started
+  become: true

--- a/ansible/roles/elasticsearch/tasks/main.yml
+++ b/ansible/roles/elasticsearch/tasks/main.yml
@@ -15,13 +15,14 @@
   ansible.builtin.apt:
     name: elasticsearch
     state: present
-    update_cache: yes
+    update_cache: true
   become: true
 
 - name: Configure Elasticsearch
   ansible.builtin.template:
     src: elasticsearch.yml.j2
     dest: /etc/elasticsearch/elasticsearch.yml
+    mode: '0644'
   notify: Restart Elasticsearch
   become: true
 
@@ -31,20 +32,4 @@
     enabled: true
     state: started
   become: true
-
-- name: Configure Elasticsearch
-  ansible.builtin.template:
-    src: elasticsearch.yml.j2
-    dest: /etc/elasticsearch/elasticsearch.yml
-    mode: '0644'  # Set file permissions to read/write for owner, read for group and others
-  notify: Restart Elasticsearch
-  become: true
-
-- name: Enable and start Elasticsearch service
-  ansible.builtin.systemd:
-    name: elasticsearch
-    enabled: true
-    state: started
-  become: true
-
   

--- a/ansible/roles/elasticsearch/tasks/main.yml
+++ b/ansible/roles/elasticsearch/tasks/main.yml
@@ -32,4 +32,4 @@
     enabled: true
     state: started
   become: true
-  
+

--- a/ansible/roles/elasticsearch/tasks/main.yml
+++ b/ansible/roles/elasticsearch/tasks/main.yml
@@ -31,3 +31,20 @@
     enabled: true
     state: started
   become: true
+
+- name: Configure Elasticsearch
+  ansible.builtin.template:
+    src: elasticsearch.yml.j2
+    dest: /etc/elasticsearch/elasticsearch.yml
+    mode: '0644'  # Set file permissions to read/write for owner, read for group and others
+  notify: Restart Elasticsearch
+  become: true
+
+- name: Enable and start Elasticsearch service
+  ansible.builtin.systemd:
+    name: elasticsearch
+    enabled: true
+    state: started
+  become: true
+
+  

--- a/ansible/roles/elasticsearch/templates/elasticsearch.yml.j2
+++ b/ansible/roles/elasticsearch/templates/elasticsearch.yml.j2
@@ -1,0 +1,5 @@
+cluster.name: elasticsearch-cluster
+node.name: "{{ ansible_hostname }}"
+network.host: 0.0.0.0
+http.port: 9200
+discovery.type: single-node

--- a/ansible/roles/kibana/tasks/main.yml
+++ b/ansible/roles/kibana/tasks/main.yml
@@ -15,30 +15,14 @@
   ansible.builtin.apt:
     name: kibana
     state: present
-    update_cache: yes
+    update_cache: true
   become: true
 
 - name: Configure Kibana
   ansible.builtin.template:
     src: kibana.yml.j2
     dest: /etc/kibana/kibana.yml
-  notify: Restart Kibana
-  become: true
-
-- name: Enable and start Kibana service
-  ansible.builtin.systemd:
-    name: kibana
-    enabled: true
-    state: started
-  become: true
-
-
-
-- name: Configure Kibana
-  ansible.builtin.template:
-    src: kibana.yml.j2
-    dest: /etc/kibana/kibana.yml
-    mode: '0644'  # Set file permissions to read/write for owner, read for group and others
+    mode: '0644'
   notify: Restart Kibana
   become: true
 

--- a/ansible/roles/kibana/tasks/main.yml
+++ b/ansible/roles/kibana/tasks/main.yml
@@ -31,4 +31,20 @@
     enabled: true
     state: started
   become: true
-  
+
+
+
+- name: Configure Kibana
+  ansible.builtin.template:
+    src: kibana.yml.j2
+    dest: /etc/kibana/kibana.yml
+    mode: '0644'  # Set file permissions to read/write for owner, read for group and others
+  notify: Restart Kibana
+  become: true
+
+- name: Enable and start Kibana service
+  ansible.builtin.systemd:
+    name: kibana
+    enabled: true
+    state: started
+  become: true

--- a/ansible/roles/kibana/tasks/main.yml
+++ b/ansible/roles/kibana/tasks/main.yml
@@ -31,3 +31,4 @@
     enabled: true
     state: started
   become: true
+  

--- a/ansible/roles/kibana/tasks/main.yml
+++ b/ansible/roles/kibana/tasks/main.yml
@@ -1,33 +1,33 @@
 ---
 - name: Import Kibana GPG key
-  apt_key:
+  ansible.builtin.apt_key:
     url: https://artifacts.elastic.co/GPG-KEY-elasticsearch
     state: present
   become: true
 
 - name: Add Kibana repository
-  apt_repository:
+  ansible.builtin.apt_repository:
     repo: 'deb https://artifacts.elastic.co/packages/7.x/apt stable main'
     state: present
   become: true
 
 - name: Install Kibana
-  apt:
+  ansible.builtin.apt:
     name: kibana
     state: present
     update_cache: yes
   become: true
 
 - name: Configure Kibana
-  template:
+  ansible.builtin.template:
     src: kibana.yml.j2
     dest: /etc/kibana/kibana.yml
   notify: Restart Kibana
   become: true
 
 - name: Enable and start Kibana service
-  systemd:
+  ansible.builtin.systemd:
     name: kibana
-    enabled: yes
+    enabled: true
     state: started
   become: true

--- a/ansible/roles/kibana/tasks/main.yml
+++ b/ansible/roles/kibana/tasks/main.yml
@@ -1,0 +1,33 @@
+---
+- name: Import Kibana GPG key
+  apt_key:
+    url: https://artifacts.elastic.co/GPG-KEY-elasticsearch
+    state: present
+  become: true
+
+- name: Add Kibana repository
+  apt_repository:
+    repo: 'deb https://artifacts.elastic.co/packages/7.x/apt stable main'
+    state: present
+  become: true
+
+- name: Install Kibana
+  apt:
+    name: kibana
+    state: present
+    update_cache: yes
+  become: true
+
+- name: Configure Kibana
+  template:
+    src: kibana.yml.j2
+    dest: /etc/kibana/kibana.yml
+  notify: Restart Kibana
+  become: true
+
+- name: Enable and start Kibana service
+  systemd:
+    name: kibana
+    enabled: yes
+    state: started
+  become: true

--- a/ansible/roles/kibana/templates/kibana.yml.j2
+++ b/ansible/roles/kibana/templates/kibana.yml.j2
@@ -1,0 +1,4 @@
+server.port: 5601
+server.host: "0.0.0.0"
+elasticsearch.hosts: ["http://localhost:9200"]
+i18n.locale: "en"

--- a/ansible/roles/metricbeat/tasks/main.yml
+++ b/ansible/roles/metricbeat/tasks/main.yml
@@ -1,29 +1,29 @@
 ---
 - name: Install Metricbeat
-  apt:
+  ansible.builtin.apt:
     name: metricbeat
     state: present
     update_cache: yes
   become: true
 
 - name: Copy Metricbeat module configurations
-  copy:
+  ansible.builtin.copy:
     src: "{{ item }}"
     dest: "/etc/metricbeat/modules.d/{{ item | basename }}"
-  loop: "{{ lookup('fileglob', 'modules.d/*.yml', wantlist=True) }}"
+  loop: "{{ query('ansible.builtin.fileglob', 'modules.d/*.yml', wantlist=True) }}"
   notify: Restart Metricbeat
   become: true
 
 - name: Configure Metricbeat
-  template:
+  ansible.builtin.template:
     src: metricbeat.yml.j2
     dest: /etc/metricbeat/metricbeat.yml
   notify: Restart Metricbeat
   become: true
 
 - name: Enable and start Metricbeat service
-  systemd:
+  ansible.builtin.systemd:
     name: metricbeat
-    enabled: yes
+    enabled: true
     state: started
   become: true

--- a/ansible/roles/metricbeat/tasks/main.yml
+++ b/ansible/roles/metricbeat/tasks/main.yml
@@ -27,3 +27,4 @@
     enabled: true
     state: started
   become: true
+  

--- a/ansible/roles/metricbeat/tasks/main.yml
+++ b/ansible/roles/metricbeat/tasks/main.yml
@@ -27,4 +27,22 @@
     enabled: true
     state: started
   become: true
+
+- name: Copy Metricbeat module configurations
+  ansible.builtin.copy:
+    src: "{{ item }}"
+    dest: "/etc/metricbeat/modules.d/{{ item | basename }}"
+    mode: '0644'  # Set file permissions to read/write for owner, read for group and others
+  loop: "{{ query('ansible.builtin.fileglob', 'modules.d/*.yml', wantlist=True) }}"
+  notify: Restart Metricbeat
+  become: true
+
+- name: Configure Metricbeat
+  ansible.builtin.template:
+    src: metricbeat.yml.j2
+    dest: /etc/metricbeat/metricbeat.yml
+    mode: '0644'  # Set file permissions to read/write for owner, read for group and others
+  notify: Restart Metricbeat
+  become: true
+
   

--- a/ansible/roles/metricbeat/tasks/main.yml
+++ b/ansible/roles/metricbeat/tasks/main.yml
@@ -3,13 +3,14 @@
   ansible.builtin.apt:
     name: metricbeat
     state: present
-    update_cache: yes
+    update_cache: true
   become: true
 
 - name: Copy Metricbeat module configurations
   ansible.builtin.copy:
     src: "{{ item }}"
     dest: "/etc/metricbeat/modules.d/{{ item | basename }}"
+    mode: '0644'
   loop: "{{ query('ansible.builtin.fileglob', 'modules.d/*.yml', wantlist=True) }}"
   notify: Restart Metricbeat
   become: true
@@ -18,6 +19,7 @@
   ansible.builtin.template:
     src: metricbeat.yml.j2
     dest: /etc/metricbeat/metricbeat.yml
+    mode: '0644'
   notify: Restart Metricbeat
   become: true
 
@@ -27,22 +29,3 @@
     enabled: true
     state: started
   become: true
-
-- name: Copy Metricbeat module configurations
-  ansible.builtin.copy:
-    src: "{{ item }}"
-    dest: "/etc/metricbeat/modules.d/{{ item | basename }}"
-    mode: '0644'  # Set file permissions to read/write for owner, read for group and others
-  loop: "{{ query('ansible.builtin.fileglob', 'modules.d/*.yml', wantlist=True) }}"
-  notify: Restart Metricbeat
-  become: true
-
-- name: Configure Metricbeat
-  ansible.builtin.template:
-    src: metricbeat.yml.j2
-    dest: /etc/metricbeat/metricbeat.yml
-    mode: '0644'  # Set file permissions to read/write for owner, read for group and others
-  notify: Restart Metricbeat
-  become: true
-
-  

--- a/ansible/roles/metricbeat/tasks/main.yml
+++ b/ansible/roles/metricbeat/tasks/main.yml
@@ -1,0 +1,29 @@
+---
+- name: Install Metricbeat
+  apt:
+    name: metricbeat
+    state: present
+    update_cache: yes
+  become: true
+
+- name: Copy Metricbeat module configurations
+  copy:
+    src: "{{ item }}"
+    dest: "/etc/metricbeat/modules.d/{{ item | basename }}"
+  loop: "{{ lookup('fileglob', 'modules.d/*.yml', wantlist=True) }}"
+  notify: Restart Metricbeat
+  become: true
+
+- name: Configure Metricbeat
+  template:
+    src: metricbeat.yml.j2
+    dest: /etc/metricbeat/metricbeat.yml
+  notify: Restart Metricbeat
+  become: true
+
+- name: Enable and start Metricbeat service
+  systemd:
+    name: metricbeat
+    enabled: yes
+    state: started
+  become: true

--- a/ansible/roles/metricbeat/templates/metricbeat.yml.j2
+++ b/ansible/roles/metricbeat/templates/metricbeat.yml.j2
@@ -1,0 +1,12 @@
+metricbeat.config.modules:
+  path: ${path.config}/modules.d/*.yml
+  reload.enabled: true
+  reload.period: 10s
+
+output.elasticsearch:
+  hosts: ["localhost:9200"] # This needs to be modified with the ip of the server where elasticsearch is running
+  username: "{{ elastic_username | default('elastic') }}"
+  password: "{{ elastic_password | default('changeme') }}"
+
+setup.kibana:
+  host: "localhost:5601"  ## This needs to be modified with the ip of the server where kibana is running


### PR DESCRIPTION
## Issue being fixed or feature implemented
This change adds initial support for Elasticsearch, Metricbeat, and Kibana through new Ansible roles. It's part of setting up monitoring and visualization for the Dash network deployment tool.

## What was done?
- Added Ansible roles for Elasticsearch, Metricbeat, and Kibana.
- Updated the `deploy.yml` file to invoke these roles.
- Placeholder entries have been added for the target hosts for these services, to be defined later.
- Note: Terraform resources for these services are not included in this PR and will be defined in subsequent updates.

## How Has This Been Tested?

## Breaking Changes
- None: This is an additive change and does not alter existing infrastructure or workflows.

## Checklist:
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone
