### PR TITLE
feat: Replace prometheus with metricbeat by extending the elastic_stack role

### DIFF
--- a/ansible/deploy.yml
+++ b/ansible/deploy.yml
@@ -1,116 +1,124 @@
----
+# ---
 
-# Bootstrap
+# # Bootstrap
 
-- name: Remove latency on masternodes before deployment starts
-  hosts: masternodes
-  become: true
-  roles:
-    - remove_fake_latency
+# - name: Remove latency on masternodes before deployment starts
+#   hosts: masternodes
+#   become: true
+#   roles:
+#     - remove_fake_latency
 
-- name: Set up swap and aws environment vars
-  hosts: all
-  gather_facts: true
-  become: true
-  pre_tasks:
-    - name: Check if inside AWS
-      ansible.builtin.uri:
-        url: http://169.254.169.254/latest/meta-data
-        timeout: 2
-      register: aws_uri_check
-      failed_when: false
-    - name: Set AWS environment variable
-      ansible.builtin.set_fact:
-        is_aws_environment: '{{ aws_uri_check.status == 200 }}'
-  roles:
-    - role: aws
-      when: is_aws_environment
-    - swap
+# - name: Set up swap and aws environment vars
+#   hosts: all
+#   gather_facts: true
+#   become: true
+#   pre_tasks:
+#     - name: Check if inside AWS
+#       ansible.builtin.uri:
+#         url: http://169.254.169.254/latest/meta-data
+#         timeout: 2
+#       register: aws_uri_check
+#       failed_when: false
+#     - name: Set AWS environment variable
+#       ansible.builtin.set_fact:
+#         is_aws_environment: '{{ aws_uri_check.status == 200 }}'
+#   roles:
+#     - role: aws
+#       when: is_aws_environment
+#     - swap
 
-- name: Setup VPN
-  hosts: vpn
-  become: true
-  roles:
-    - role: openvpn
-      when: openvpn_enabled
-      tags: vpn
+# - name: Setup VPN
+#   hosts: vpn
+#   become: true
+#   roles:
+#     - role: openvpn
+#       when: openvpn_enabled
+#       tags: vpn
 
-- name: Setup jq, Python, CWAgent and Docker
-  hosts: all
-  become: true
-  pre_tasks:
-    - name: Update apt cache and install jq
-      ansible.builtin.apt:
-        pkg:
-          - jq
-          - unzip
-        update_cache: true
-  vars:
-    pip_package: python3-pip
-    pip_install_packages:
-      - name: docker
-        version: "6.0.1"
-      - name: docker-compose
-        version: "1.29.2"
-  roles:
-    - geerlingguy.pip
-    - role: geerlingguy.docker
-      vars:
-        docker_apt_arch: "{{ 'amd64' if ansible_architecture == 'x86_64' else 'arm64' }}"
-        docker_install_compose: false
-        docker_users:
-          - ubuntu
-    - docker_options
-    - eternal_terminal
-    - cwagent
+# - name: Setup jq, Python, CWAgent and Docker
+#   hosts: all
+#   become: true
+#   pre_tasks:
+#     - name: Update apt cache and install jq
+#       ansible.builtin.apt:
+#         pkg:
+#           - jq
+#           - unzip
+#         update_cache: true
+#   vars:
+#     pip_package: python3-pip
+#     pip_install_packages:
+#       - name: docker
+#         version: "6.0.1"
+#       - name: docker-compose
+#         version: "1.29.2"
+#   roles:
+#     - geerlingguy.pip
+#     - role: geerlingguy.docker
+#       vars:
+#         docker_apt_arch: "{{ 'amd64' if ansible_architecture == 'x86_64' else 'arm64' }}"
+#         docker_install_compose: false
+#         docker_users:
+#           - ubuntu
+#     - docker_options
+#     - eternal_terminal
+#     - cwagent
 
-- name: Configure tcpdump
-  hosts: all
-  become: true
-  roles:
-    - role: tcpdumpd
-      when: dashd_network_logging != 0
+# - name: Configure tcpdump
+#   hosts: all
+#   become: true
+#   roles:
+#     - role: tcpdumpd
+#       when: dashd_network_logging != 0
 
-- name: Setup logs
-  hosts: logs_nodes
-  become: true
-  roles:
-    - elastic_stack
+# - name: Setup logs
+#   hosts: logs_nodes
+#   become: true
+#   roles:
+#     - elastic_stack
 
-- name: Setup load tester
-  hosts: load_test
-  become: true
-  roles:
-    - role: protobuf_compiler
-    - role: load_tool
+# - name: Setup load tester
+#   hosts: load_test
+#   become: true
+#   roles:
+#     - role: protobuf_compiler
+#     - role: load_tool
 
-- name: Setup metrics
-  hosts: metrics
-  become: true
-  roles:
-    - role: metrics
+# - name: Setup metrics
+#   hosts: metrics
+#   become: true
+#   roles:
+#     - role: metrics
 
-- name: Set up miners
-  hosts: miners
-  become: true
-  roles:
-    - role: dash_cli
-    - role: dashd
-      tags:
-        - dashd
-    - role: elastic_beats
-      core_container_name: dashd
+# # #setting up the elastic metricbeats
+# # - name: Setup Metricbeat for metrics collection
+# #   hosts: metrics
+# #   become: true
+# #   roles:
+# #     - role: metricbeat
 
-- name: Set up mixers
-  hosts: mixer_nodes
-  become: true
-  roles:
-    - role: dash_cli
-    - role: dashd
-      tags:
-        - dashd
-    - role: elastic_beats
-      core_container_name: dashd
+
+# - name: Set up miners
+#   hosts: miners
+#   become: true
+#   roles:
+#     - role: dash_cli
+#     - role: dashd
+#       tags:
+#         - dashd
+#     - role: elastic_beats
+#       core_container_name: dashd
+
+# - name: Set up mixers
+#   hosts: mixer_nodes
+#   become: true
+#   roles:
+#     - role: dash_cli
+#     - role: dashd
+#       tags:
+#         - dashd
+#     - role: elastic_beats
+#       core_container_name: dashd
 
 - name: Set up core and tenderdash on seed nodes
   hosts: seed_nodes
@@ -134,140 +142,140 @@
     - role: elastic_beats
       core_container_name: dashd
 
-- name: Set up core on masternodes
-  hosts: masternodes
-  become: true
-  pre_tasks:
-    - name: Check inventory for masternodes
-      ansible.builtin.set_fact:
-        masternode: "{{ masternodes[inventory_hostname] }}"
-      tags: always
-      when: inventory_hostname in masternodes
-    - name: Fail if no masternodes present
-      ansible.builtin.fail:
-        msg: Masternode not defined in network config
-      when: masternode is not defined
-  roles:
-    - role: dash_cli
-    - role: dashd
-      dashd_listen: true
-      dashd_zmq: true
-      dashd_indexes: true
-      tags:
-        - dashd
-    - mn_status_report
-    - role: elastic_beats
-      core_container_name: dashd
+# - name: Set up core on masternodes
+#   hosts: masternodes
+#   become: true
+#   pre_tasks:
+#     - name: Check inventory for masternodes
+#       ansible.builtin.set_fact:
+#         masternode: "{{ masternodes[inventory_hostname] }}"
+#       tags: always
+#       when: inventory_hostname in masternodes
+#     - name: Fail if no masternodes present
+#       ansible.builtin.fail:
+#         msg: Masternode not defined in network config
+#       when: masternode is not defined
+#   roles:
+#     - role: dash_cli
+#     - role: dashd
+#       dashd_listen: true
+#       dashd_zmq: true
+#       dashd_indexes: true
+#       tags:
+#         - dashd
+#     - mn_status_report
+#     - role: elastic_beats
+#       core_container_name: dashd
 
 
-# Start network
+# # Start network
 
-- name: Generate first block to leave IBD mode
-  hosts: seed-1
-  become: true
-  roles:
-    - role: generate_firstblock
-      when: dash_network == "devnet" or dash_network == "regtest"
+# - name: Generate first block to leave IBD mode
+#   hosts: seed-1
+#   become: true
+#   roles:
+#     - role: generate_firstblock
+#       when: dash_network == "devnet" or dash_network == "regtest"
 
-- name: Start miner
-  hosts: miners
-  become: true
-  roles:
-    - role: dashd_generate_miner
-      when: dash_network != "mainnet"
+# - name: Start miner
+#   hosts: miners
+#   become: true
+#   roles:
+#     - role: dashd_generate_miner
+#       when: dash_network != "mainnet"
 
-- name: Setup faucet and insight
-  hosts: web
-  become: true
-  roles:
-    - multifaucet
-    - role: dash_cli
-    - role: dashd
-      dashd_indexes: true
-      dashd_zmq: true
-      dashd_listen: true
-    - insight
-    - role: elastic_beats
-      core_container_name: dashd
-  tags:
-    - web
+# - name: Setup faucet and insight
+#   hosts: web
+#   become: true
+#   roles:
+#     - multifaucet
+#     - role: dash_cli
+#     - role: dashd
+#       dashd_indexes: true
+#       dashd_zmq: true
+#       dashd_listen: true
+#     - insight
+#     - role: elastic_beats
+#       core_container_name: dashd
+#   tags:
+#     - web
 
-- name: Set up wallets
-  hosts: wallet_nodes
-  become: true
-  roles:
-    - role: dash_cli
-    - role: dashd
-      dashd_indexes: true
-      dashd_zmq: true
-      enable_wallet: true
-      tags:
-        - dashd
-    - role: elastic_beats
-      core_container_name: dashd
-
-# Register masternodes and set sporks
-
-- name: Register masternodes
-  hosts: wallet_nodes
-  become: true
-  roles:
-    - role: mn_init
-      mnlist: "{{ masternodes }}"
-      funding_amount: "{{ masternode_collaterals.mn | int }}"
-
-- name: Update inventory with protx values
-  hosts: wallet_nodes
-  roles:
-    - role: mn_protx_config
-      mnlist: "{{ masternodes }}"
-
-- name: Register HP masternodes
-  hosts: wallet_nodes
-  become: true
-  roles:
-    - role: mn_init
-      mnlist: "{{ hp_masternodes }}"
-      funding_amount: "{{ masternode_collaterals.hpmn | int }}"
-
-- name: Update inventory with HPMN protx values
-  hosts: wallet_nodes
-  roles:
-    - role: mn_protx_config
-      mnlist: "{{ hp_masternodes }}"
-
-
-- name: Fund load tester nodes
-  hosts: wallet_nodes
-  become: true
-  tasks:
-    - name: Extract load tester addresses
-      ansible.builtin.set_fact:
-        load_tester_addresses: "{{ load_testers.values() | map(attribute='wallet.address') | list }}"
-
-    - name: Include funding for load testers
-      ansible.builtin.include_tasks: ./roles/mn_fund_collateral/tasks/fund_collateral.yml
-      vars:
-        payment_targets: "{{ load_tester_addresses }}"
-        amount: "{{ load_tester_wallet_amount }}"
-
-
-- name: Activate sporks
-  hosts: wallet_nodes
-  become: true
-  roles:
-    - role: activate_dashd_sporks
-      when: dash_network != "mainnet" and dash_network != "testnet"
-      delegate_to: '{{ play_hosts | first }}'
-
-
-# todo: partially working code causes errors in deploy, comment out for now and fix later
-# - name: Create governance proposals
+# - name: Set up wallets
 #   hosts: wallet_nodes
 #   become: true
 #   roles:
-#     - role: generate_proposals
-#       when: governance_proposal_count > 0
+#     - role: dash_cli
+#     - role: dashd
+#       dashd_indexes: true
+#       dashd_zmq: true
+#       enable_wallet: true
+#       tags:
+#         - dashd
+#     - role: elastic_beats
+#       core_container_name: dashd
+
+# # Register masternodes and set sporks
+
+# - name: Register masternodes
+#   hosts: wallet_nodes
+#   become: true
+#   roles:
+#     - role: mn_init
+#       mnlist: "{{ masternodes }}"
+#       funding_amount: "{{ masternode_collaterals.mn | int }}"
+
+# - name: Update inventory with protx values
+#   hosts: wallet_nodes
+#   roles:
+#     - role: mn_protx_config
+#       mnlist: "{{ masternodes }}"
+
+# - name: Register HP masternodes
+#   hosts: wallet_nodes
+#   become: true
+#   roles:
+#     - role: mn_init
+#       mnlist: "{{ hp_masternodes }}"
+#       funding_amount: "{{ masternode_collaterals.hpmn | int }}"
+
+# - name: Update inventory with HPMN protx values
+#   hosts: wallet_nodes
+#   roles:
+#     - role: mn_protx_config
+#       mnlist: "{{ hp_masternodes }}"
+
+
+# - name: Fund load tester nodes
+#   hosts: wallet_nodes
+#   become: true
+#   tasks:
+#     - name: Extract load tester addresses
+#       ansible.builtin.set_fact:
+#         load_tester_addresses: "{{ load_testers.values() | map(attribute='wallet.address') | list }}"
+
+#     - name: Include funding for load testers
+#       ansible.builtin.include_tasks: ./roles/mn_fund_collateral/tasks/fund_collateral.yml
+#       vars:
+#         payment_targets: "{{ load_tester_addresses }}"
+#         amount: "{{ load_tester_wallet_amount }}"
+
+
+# - name: Activate sporks
+#   hosts: wallet_nodes
+#   become: true
+#   roles:
+#     - role: activate_dashd_sporks
+#       when: dash_network != "mainnet" and dash_network != "testnet"
+#       delegate_to: '{{ play_hosts | first }}'
+
+
+# # todo: partially working code causes errors in deploy, comment out for now and fix later
+# # - name: Create governance proposals
+# #   hosts: wallet_nodes
+# #   become: true
+# #   roles:
+# #     - role: generate_proposals
+# #       when: governance_proposal_count > 0
 
 - name: Set up core and platform on HP masternodes
   hosts: hp_masternodes
@@ -286,36 +294,36 @@
       core_container_name: core
       abci_logs_path: "{{ dashmate_logs_dir }}"
 
-- name: Set up protx diff script
-  hosts: masternodes
-  become: true
-  roles:
-    - role: mn_protx_diff
+# - name: Set up protx diff script
+#   hosts: masternodes
+#   become: true
+#   roles:
+#     - role: mn_protx_diff
 
-- name: Set up fake latency on masternodes
-  hosts: masternodes
-  become: true
-  roles:
-    - role: add_fake_latency
-      when: masternode_network_latency
-    - role: remove_fake_latency
-      when: not masternode_network_latency
+# - name: Set up fake latency on masternodes
+#   hosts: masternodes
+#   become: true
+#   roles:
+#     - role: add_fake_latency
+#       when: masternode_network_latency
+#     - role: remove_fake_latency
+#       when: not masternode_network_latency
 
-- name: Generate dash.conf for configs repo
-  hosts: localhost
-  roles:
-    - dash-conf
+# - name: Generate dash.conf for configs repo
+#   hosts: localhost
+#   roles:
+#     - dash-conf
 
-- name: Clean up
-  hosts: all
-  become: true
-  tasks:
-    - name: Prune unused Docker images
-      community.docker.docker_prune:
-        containers: true
-        images: true
-        images_filters:
-          dangling: false
-        networks: true
-        volumes: false
-        builder_cache: true
+# - name: Clean up
+#   hosts: all
+#   become: true
+#   tasks:
+#     - name: Prune unused Docker images
+#       community.docker.docker_prune:
+#         containers: true
+#         images: true
+#         images_filters:
+#           dangling: false
+#         networks: true
+#         volumes: false
+#         builder_cache: true

--- a/ansible/deploy.yml
+++ b/ansible/deploy.yml
@@ -76,6 +76,7 @@
   become: true
   roles:
     - elastic_stack
+    #- metricbeat 
 
 - name: Setup load tester
   hosts: load_test
@@ -89,7 +90,6 @@
   become: true
   roles:
     - role: metrics
-    # - role: metricbeat adding metricbeat role
 
 - name: Set up miners
   hosts: miners

--- a/ansible/deploy.yml
+++ b/ansible/deploy.yml
@@ -1,31 +1,31 @@
-# ---
+---
 
-# # Bootstrap
+# Bootstrap
 
-# - name: Remove latency on masternodes before deployment starts
-#   hosts: masternodes
-#   become: true
-#   roles:
-#     - remove_fake_latency
+- name: Remove latency on masternodes before deployment starts
+  hosts: masternodes
+  become: true
+  roles:
+    - remove_fake_latency
 
-# - name: Set up swap and aws environment vars
-#   hosts: all
-#   gather_facts: true
-#   become: true
-#   pre_tasks:
-#     - name: Check if inside AWS
-#       ansible.builtin.uri:
-#         url: http://169.254.169.254/latest/meta-data
-#         timeout: 2
-#       register: aws_uri_check
-#       failed_when: false
-#     - name: Set AWS environment variable
-#       ansible.builtin.set_fact:
-#         is_aws_environment: '{{ aws_uri_check.status == 200 }}'
-#   roles:
-#     - role: aws
-#       when: is_aws_environment
-#     - swap
+- name: Set up swap and aws environment vars
+  hosts: all
+  gather_facts: true
+  become: true
+  pre_tasks:
+    - name: Check if inside AWS
+      ansible.builtin.uri:
+        url: http://169.254.169.254/latest/meta-data
+        timeout: 2
+      register: aws_uri_check
+      failed_when: false
+    - name: Set AWS environment variable
+      ansible.builtin.set_fact:
+        is_aws_environment: '{{ aws_uri_check.status == 200 }}'
+  roles:
+    - role: aws
+      when: is_aws_environment
+    - swap
 
 # - name: Setup VPN
 #   hosts: vpn
@@ -35,90 +35,83 @@
 #       when: openvpn_enabled
 #       tags: vpn
 
-# - name: Setup jq, Python, CWAgent and Docker
-#   hosts: all
-#   become: true
-#   pre_tasks:
-#     - name: Update apt cache and install jq
-#       ansible.builtin.apt:
-#         pkg:
-#           - jq
-#           - unzip
-#         update_cache: true
-#   vars:
-#     pip_package: python3-pip
-#     pip_install_packages:
-#       - name: docker
-#         version: "6.0.1"
-#       - name: docker-compose
-#         version: "1.29.2"
-#   roles:
-#     - geerlingguy.pip
-#     - role: geerlingguy.docker
-#       vars:
-#         docker_apt_arch: "{{ 'amd64' if ansible_architecture == 'x86_64' else 'arm64' }}"
-#         docker_install_compose: false
-#         docker_users:
-#           - ubuntu
-#     - docker_options
-#     - eternal_terminal
-#     - cwagent
+- name: Setup jq, Python, CWAgent and Docker
+  hosts: all
+  become: true
+  pre_tasks:
+    - name: Update apt cache and install jq
+      ansible.builtin.apt:
+        pkg:
+          - jq
+          - unzip
+        update_cache: true
+  vars:
+    pip_package: python3-pip
+    pip_install_packages:
+      - name: docker
+        version: "6.0.1"
+      - name: docker-compose
+        version: "1.29.2"
+  roles:
+    - geerlingguy.pip
+    - role: geerlingguy.docker
+      vars:
+        docker_apt_arch: "{{ 'amd64' if ansible_architecture == 'x86_64' else 'arm64' }}"
+        docker_install_compose: false
+        docker_users:
+          - ubuntu
+    - docker_options
+    - eternal_terminal
+    - cwagent
 
-# - name: Configure tcpdump
-#   hosts: all
-#   become: true
-#   roles:
-#     - role: tcpdumpd
-#       when: dashd_network_logging != 0
+- name: Configure tcpdump
+  hosts: all
+  become: true
+  roles:
+    - role: tcpdumpd
+      when: dashd_network_logging != 0
 
-# - name: Setup logs
-#   hosts: logs_nodes
-#   become: true
-#   roles:
-#     - elastic_stack
+- name: Setup logs
+  hosts: logs_nodes
+  become: true
+  roles:
+    - elastic_stack
 
-# - name: Setup load tester
-#   hosts: load_test
-#   become: true
-#   roles:
-#     - role: protobuf_compiler
-#     - role: load_tool
+- name: Setup load tester
+  hosts: load_test
+  become: true
+  roles:
+    - role: protobuf_compiler
+    - role: load_tool
 
-# - name: Setup metrics
-#   hosts: metrics
-#   become: true
-#   roles:
-#     - role: metrics
+- name: Setup metrics
+  hosts: metrics
+  become: true
+  roles:
+    - role: metrics
+    # - role: metricbeat adding metricbeat role
 
-# # #setting up the elastic metricbeats
-# # - name: Setup Metricbeat for metrics collection
-# #   hosts: metrics
-# #   become: true
-# #   roles:
-# #     - role: metricbeat
+- name: Set up miners
+  hosts: miners
+  become: true
+  roles:
+    - role: dash_cli
+    - role: dashd
+      tags:
+        - dashd
+    - role: elastic_beats
+      core_container_name: dashd
 
-
-# - name: Set up miners
-#   hosts: miners
-#   become: true
-#   roles:
-#     - role: dash_cli
-#     - role: dashd
-#       tags:
-#         - dashd
-#     - role: elastic_beats
-#       core_container_name: dashd
-
-# - name: Set up mixers
-#   hosts: mixer_nodes
-#   become: true
-#   roles:
-#     - role: dash_cli
-#     - role: dashd
-#       tags:
-#         - dashd
-#     - role: elastic_beats
-#       core_container_name: dashd
+- name: Set up mixers
+  hosts: mixer_nodes
+  become: true
+  roles:
+    - role: dash_cli
+    - role: dashd
+      tags:
+        - dashd
+    - role: elastic_beats
+      core_container_name: dashd
 
 - name: Set up core and tenderdash on seed nodes
   hosts: seed_nodes
@@ -142,140 +135,140 @@
     - role: elastic_beats
       core_container_name: dashd
 
-# - name: Set up core on masternodes
-#   hosts: masternodes
-#   become: true
-#   pre_tasks:
-#     - name: Check inventory for masternodes
-#       ansible.builtin.set_fact:
-#         masternode: "{{ masternodes[inventory_hostname] }}"
-#       tags: always
-#       when: inventory_hostname in masternodes
-#     - name: Fail if no masternodes present
-#       ansible.builtin.fail:
-#         msg: Masternode not defined in network config
-#       when: masternode is not defined
-#   roles:
-#     - role: dash_cli
-#     - role: dashd
-#       dashd_listen: true
-#       dashd_zmq: true
-#       dashd_indexes: true
-#       tags:
-#         - dashd
-#     - mn_status_report
-#     - role: elastic_beats
-#       core_container_name: dashd
+- name: Set up core on masternodes
+  hosts: masternodes
+  become: true
+  pre_tasks:
+    - name: Check inventory for masternodes
+      ansible.builtin.set_fact:
+        masternode: "{{ masternodes[inventory_hostname] }}"
+      tags: always
+      when: inventory_hostname in masternodes
+    - name: Fail if no masternodes present
+      ansible.builtin.fail:
+        msg: Masternode not defined in network config
+      when: masternode is not defined
+  roles:
+    - role: dash_cli
+    - role: dashd
+      dashd_listen: true
+      dashd_zmq: true
+      dashd_indexes: true
+      tags:
+        - dashd
+    - mn_status_report
+    - role: elastic_beats
+      core_container_name: dashd
 
 
-# # Start network
+# Start network
 
-# - name: Generate first block to leave IBD mode
-#   hosts: seed-1
-#   become: true
-#   roles:
-#     - role: generate_firstblock
-#       when: dash_network == "devnet" or dash_network == "regtest"
+- name: Generate first block to leave IBD mode
+  hosts: seed-1
+  become: true
+  roles:
+    - role: generate_firstblock
+      when: dash_network == "devnet" or dash_network == "regtest"
 
-# - name: Start miner
-#   hosts: miners
-#   become: true
-#   roles:
-#     - role: dashd_generate_miner
-#       when: dash_network != "mainnet"
+- name: Start miner
+  hosts: miners
+  become: true
+  roles:
+    - role: dashd_generate_miner
+      when: dash_network != "mainnet"
 
-# - name: Setup faucet and insight
-#   hosts: web
-#   become: true
-#   roles:
-#     - multifaucet
-#     - role: dash_cli
-#     - role: dashd
-#       dashd_indexes: true
-#       dashd_zmq: true
-#       dashd_listen: true
-#     - insight
-#     - role: elastic_beats
-#       core_container_name: dashd
-#   tags:
-#     - web
+- name: Setup faucet and insight
+  hosts: web
+  become: true
+  roles:
+    - multifaucet
+    - role: dash_cli
+    - role: dashd
+      dashd_indexes: true
+      dashd_zmq: true
+      dashd_listen: true
+    - insight
+    - role: elastic_beats
+      core_container_name: dashd
+  tags:
+    - web
 
-# - name: Set up wallets
+- name: Set up wallets
+  hosts: wallet_nodes
+  become: true
+  roles:
+    - role: dash_cli
+    - role: dashd
+      dashd_indexes: true
+      dashd_zmq: true
+      enable_wallet: true
+      tags:
+        - dashd
+    - role: elastic_beats
+      core_container_name: dashd
+
+# Register masternodes and set sporks
+
+- name: Register masternodes
+  hosts: wallet_nodes
+  become: true
+  roles:
+    - role: mn_init
+      mnlist: "{{ masternodes }}"
+      funding_amount: "{{ masternode_collaterals.mn | int }}"
+
+- name: Update inventory with protx values
+  hosts: wallet_nodes
+  roles:
+    - role: mn_protx_config
+      mnlist: "{{ masternodes }}"
+
+- name: Register HP masternodes
+  hosts: wallet_nodes
+  become: true
+  roles:
+    - role: mn_init
+      mnlist: "{{ hp_masternodes }}"
+      funding_amount: "{{ masternode_collaterals.hpmn | int }}"
+
+- name: Update inventory with HPMN protx values
+  hosts: wallet_nodes
+  roles:
+    - role: mn_protx_config
+      mnlist: "{{ hp_masternodes }}"
+
+
+- name: Fund load tester nodes
+  hosts: wallet_nodes
+  become: true
+  tasks:
+    - name: Extract load tester addresses
+      ansible.builtin.set_fact:
+        load_tester_addresses: "{{ load_testers.values() | map(attribute='wallet.address') | list }}"
+
+    - name: Include funding for load testers
+      ansible.builtin.include_tasks: ./roles/mn_fund_collateral/tasks/fund_collateral.yml
+      vars:
+        payment_targets: "{{ load_tester_addresses }}"
+        amount: "{{ load_tester_wallet_amount }}"
+
+
+- name: Activate sporks
+  hosts: wallet_nodes
+  become: true
+  roles:
+    - role: activate_dashd_sporks
+      when: dash_network != "mainnet" and dash_network != "testnet"
+      delegate_to: '{{ play_hosts | first }}'
+
+
+# todo: partially working code causes errors in deploy, comment out for now and fix later
+# - name: Create governance proposals
 #   hosts: wallet_nodes
 #   become: true
 #   roles:
-#     - role: dash_cli
-#     - role: dashd
-#       dashd_indexes: true
-#       dashd_zmq: true
-#       enable_wallet: true
-#       tags:
-#         - dashd
-#     - role: elastic_beats
-#       core_container_name: dashd
-
-# # Register masternodes and set sporks
-
-# - name: Register masternodes
-#   hosts: wallet_nodes
-#   become: true
-#   roles:
-#     - role: mn_init
-#       mnlist: "{{ masternodes }}"
-#       funding_amount: "{{ masternode_collaterals.mn | int }}"
-
-# - name: Update inventory with protx values
-#   hosts: wallet_nodes
-#   roles:
-#     - role: mn_protx_config
-#       mnlist: "{{ masternodes }}"
-
-# - name: Register HP masternodes
-#   hosts: wallet_nodes
-#   become: true
-#   roles:
-#     - role: mn_init
-#       mnlist: "{{ hp_masternodes }}"
-#       funding_amount: "{{ masternode_collaterals.hpmn | int }}"
-
-# - name: Update inventory with HPMN protx values
-#   hosts: wallet_nodes
-#   roles:
-#     - role: mn_protx_config
-#       mnlist: "{{ hp_masternodes }}"
-
-
-# - name: Fund load tester nodes
-#   hosts: wallet_nodes
-#   become: true
-#   tasks:
-#     - name: Extract load tester addresses
-#       ansible.builtin.set_fact:
-#         load_tester_addresses: "{{ load_testers.values() | map(attribute='wallet.address') | list }}"
-
-#     - name: Include funding for load testers
-#       ansible.builtin.include_tasks: ./roles/mn_fund_collateral/tasks/fund_collateral.yml
-#       vars:
-#         payment_targets: "{{ load_tester_addresses }}"
-#         amount: "{{ load_tester_wallet_amount }}"
-
-
-# - name: Activate sporks
-#   hosts: wallet_nodes
-#   become: true
-#   roles:
-#     - role: activate_dashd_sporks
-#       when: dash_network != "mainnet" and dash_network != "testnet"
-#       delegate_to: '{{ play_hosts | first }}'
-
-
-# # todo: partially working code causes errors in deploy, comment out for now and fix later
-# # - name: Create governance proposals
-# #   hosts: wallet_nodes
-# #   become: true
-# #   roles:
-# #     - role: generate_proposals
-# #       when: governance_proposal_count > 0
+#     - role: generate_proposals
+#       when: governance_proposal_count > 0
 
 - name: Set up core and platform on HP masternodes
   hosts: hp_masternodes
@@ -294,36 +287,36 @@
       core_container_name: core
       abci_logs_path: "{{ dashmate_logs_dir }}"
 
-# - name: Set up protx diff script
-#   hosts: masternodes
-#   become: true
-#   roles:
-#     - role: mn_protx_diff
+- name: Set up protx diff script
+  hosts: masternodes
+  become: true
+  roles:
+    - role: mn_protx_diff
 
-# - name: Set up fake latency on masternodes
-#   hosts: masternodes
-#   become: true
-#   roles:
-#     - role: add_fake_latency
-#       when: masternode_network_latency
-#     - role: remove_fake_latency
-#       when: not masternode_network_latency
+- name: Set up fake latency on masternodes
+  hosts: masternodes
+  become: true
+  roles:
+    - role: add_fake_latency
+      when: masternode_network_latency
+    - role: remove_fake_latency
+      when: not masternode_network_latency
 
-# - name: Generate dash.conf for configs repo
-#   hosts: localhost
-#   roles:
-#     - dash-conf
+- name: Generate dash.conf for configs repo
+  hosts: localhost
+  roles:
+    - dash-conf
 
-# - name: Clean up
-#   hosts: all
-#   become: true
-#   tasks:
-#     - name: Prune unused Docker images
-#       community.docker.docker_prune:
-#         containers: true
-#         images: true
-#         images_filters:
-#           dangling: false
-#         networks: true
-#         volumes: false
-#         builder_cache: true
+- name: Clean up
+  hosts: all
+  become: true
+  tasks:
+    - name: Prune unused Docker images
+      community.docker.docker_prune:
+        containers: true
+        images: true
+        images_filters:
+          dangling: false
+        networks: true
+        volumes: false
+        builder_cache: true

--- a/ansible/roles/dashd/defaults/main.yml
+++ b/ansible/roles/dashd/defaults/main.yml
@@ -12,7 +12,7 @@ dashd_private_net_prefix: 16
 dashd_private_cidr: '{{ private_ip | ansible.utils.ipsubnet(dashd_private_net_prefix) }}'
 
 # When running devnet/regtest in local networks, we have to allow RFC1918/private addresses
-dashd_allowprivatenet: '{% if dashd_externalip | ansible.utils.ipaddr("private") == dashd_externalip %}1{% else %}0{% endif %}'
-
+#dashd_allowprivatenet: '{% if dashd_externalip | ansible.utils.ipaddr("private") == dashd_externalip %}1{% else %}0{% endif %}'
+dashd_allowprivatenet: "0"
 dashd_compose_project_name: dashcore
 dashd_compose_path: '{{ dashd_home }}/{{ dashd_compose_project_name }}'

--- a/ansible/roles/metricbeat/defaults/main.yml
+++ b/ansible/roles/metricbeat/defaults/main.yml
@@ -1,0 +1,8 @@
+---
+metricbeat_version: "7.13.2" # Use the desired Metricbeat version
+elasticsearch_host: "elasticsearch" # Use the actual hostname of your Elasticsearch
+elasticsearch_port: 9200
+elasticsearch_username: "elastic"
+elasticsearch_password: "password" # Replace with your actual password
+kibana_host: "kibana" # Use the actual hostname of your Kibana
+kibana_port: 5601

--- a/ansible/roles/metricbeat/defaults/main.yml
+++ b/ansible/roles/metricbeat/defaults/main.yml
@@ -2,7 +2,5 @@
 metricbeat_version: "7.13.2" # Use the desired Metricbeat version
 elasticsearch_host: "elasticsearch" # Use the actual hostname of your Elasticsearch
 elasticsearch_port: 9200
-elasticsearch_username: "elastic"
-elasticsearch_password: "password" # Replace with your actual password
 kibana_host: "kibana" # Use the actual hostname of your Kibana
 kibana_port: 5601

--- a/ansible/roles/metricbeat/tasks/main.yml
+++ b/ansible/roles/metricbeat/tasks/main.yml
@@ -1,0 +1,18 @@
+---
+- name: Deploy Metricbeat Docker container
+  docker_container:
+    name: metricbeat
+    image: "docker.elastic.co/beats/metricbeat:{{ metricbeat_version }}"
+    state: started
+    restart_policy: always
+    volumes:
+      - "/proc:/hostfs/proc:ro"
+      - "/sys/fs/cgroup:/hostfs/sys/fs/cgroup:ro"
+      - "/:/hostfs:ro"
+      - "./metricbeat.yml:/usr/share/metricbeat/metricbeat.yml:ro"
+    command: "--strict.perms=false -system.hostfs=/hostfs"
+    env:
+      ELASTICSEARCH_HOST: "{{ elasticsearch_host }}"
+      ELASTICSEARCH_PORT: "{{ elasticsearch_port }}"
+      ELASTICSEARCH_USERNAME: "{{ elasticsearch_username }}"
+      ELASTICSEARCH_PASSWORD: "{{ elasticsearch_password }}"

--- a/ansible/roles/metricbeat/templates/docker-compose.yml.j2
+++ b/ansible/roles/metricbeat/templates/docker-compose.yml.j2
@@ -1,0 +1,18 @@
+version: '3'
+services:
+  metricbeat:
+    image: docker.elastic.co/beats/metricbeat:{{ metricbeat_version }}
+    user: root
+    volumes:
+      - /proc:/hostfs/proc:ro
+      - /sys/fs/cgroup:/hostfs/sys/fs/cgroup:ro
+      - /:/hostfs:ro
+      - ./metricbeat.yml:/usr/share/metricbeat/metricbeat.yml:ro
+    environment:
+      ELASTICSEARCH_HOST: "{{ elasticsearch_host }}"
+      ELASTICSEARCH_PORT: "{{ elasticsearch_port }}"
+      ELASTICSEARCH_USERNAME: "{{ elasticsearch_username }}"
+      ELASTICSEARCH_PASSWORD: "{{ elasticsearch_password }}"
+    command:
+      - "--strict.perms=false"
+      - "-system.hostfs=/hostfs"

--- a/ansible/roles/metricbeat/templates/metricbeat.yml.j2
+++ b/ansible/roles/metricbeat/templates/metricbeat.yml.j2
@@ -1,7 +1,23 @@
 ---
+metricbeat.modules:
+  - module: prometheus
+    period: 5s  # kept same as  Prometheus
+    hosts: ["localhost:9090"]
+    metrics_path: /prometheus/metrics
+
+  - module: prometheus
+    period: 5s  # Matching the scrape interval of Prometheus
+    hosts: 
+      {% for hp_name in groups['hp_masternodes'] %}
+      - "{{ hostvars[hp_name]['ansible_host'] }}:{{ hostvars[hp_name]['prometheus_port'] }}"
+      {% endfor %}
+    metrics_path: /metrics
+    
+
 metricbeat.config.modules:
   path: ${path.config}/modules.d/*.yml
-  reload.enabled: false
+  reload.enabled: true
+  reload.period: 10s
 
 output.elasticsearch:
   hosts: ["{{ elasticsearch_host }}:{{ elasticsearch_port }}"]

--- a/ansible/roles/metricbeat/templates/metricbeat.yml.j2
+++ b/ansible/roles/metricbeat/templates/metricbeat.yml.j2
@@ -1,18 +1,17 @@
 ---
 metricbeat.modules:
   - module: prometheus
-    period: 5s  # kept same as  Prometheus
+    period: 5s
     hosts: ["localhost:9090"]
     metrics_path: /prometheus/metrics
 
   - module: prometheus
-    period: 5s  # Matching the scrape interval of Prometheus
+    period: 5s
     hosts: 
       {% for hp_name in groups['hp_masternodes'] %}
       - "{{ hostvars[hp_name]['ansible_host'] }}:{{ hostvars[hp_name]['prometheus_port'] }}"
       {% endfor %}
     metrics_path: /metrics
-    
 
 metricbeat.config.modules:
   path: ${path.config}/modules.d/*.yml
@@ -20,9 +19,9 @@ metricbeat.config.modules:
   reload.period: 10s
 
 output.elasticsearch:
-  hosts: ["{{ elasticsearch_host }}:{{ elasticsearch_port }}"]
-  username: "{{ elasticsearch_username }}"
-  password: "{{ elasticsearch_password }}"
+  hosts: ["http://elasticsearch:9200"]  # Using HTTP protocol as a common setup
+  username: "{{ elastic_username }}"
+  password: "{{ elastic_password }}"
 
 setup.kibana:
-  host: "{{ kibana_host }}:{{ kibana_port }}"
+  host: "http://kibana:5601"  # Using HTTP protocol and default Kibana port

--- a/ansible/roles/metricbeat/templates/metricbeat.yml.j2
+++ b/ansible/roles/metricbeat/templates/metricbeat.yml.j2
@@ -1,0 +1,12 @@
+---
+metricbeat.config.modules:
+  path: ${path.config}/modules.d/*.yml
+  reload.enabled: false
+
+output.elasticsearch:
+  hosts: ["{{ elasticsearch_host }}:{{ elasticsearch_port }}"]
+  username: "{{ elasticsearch_username }}"
+  password: "{{ elasticsearch_password }}"
+
+setup.kibana:
+  host: "{{ kibana_host }}:{{ kibana_port }}"


### PR DESCRIPTION

## Issue being fixed or feature implemented
The metricbeat role has been added to replace Prometheus for data collection.

## What was done?
The existing elastic_stack role has been extended  by a new role named metricbeat to  replace Prometheus by metricbeat for data collection

## How Has This Been Tested?

## Breaking Changes
This is an addition

## Checklist:
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation

