### PR TITLE
Fix: check which network we're on for dashmate

### DIFF
--- a/ansible/roles/dashmate/templates/dashmate.json.j2
+++ b/ansible/roles/dashmate/templates/dashmate.json.j2
@@ -188,11 +188,19 @@
             "validatorSet": {
               "llmqType": {{ platform_drive_validator_set_llmq_type }}
             },
+            {% if dash_network == "devnet" %}
             "chainLock": {
               "llmqType": 101,
               "llmqSize": 12,
               "dkgInterval": 24
             },
+            {% else %}
+            "chainLock": {
+              "llmqType": 1,
+              "llmqSize": 50,
+              "dkgInterval": 24
+            },
+            {% endif %}
             "epochTime": {{ platform_drive_abci_epoch_time }}
           },
           "tenderdash": {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
We need to define chainlocks for dashmate, this checks if we're on a devnet or not and fills the llmq in appropriately.


## What was done?
Simple if/else to check if we're on a devnet or not


## How Has This Been Tested?
Deployment


## Breaking Changes
None


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone
