### PR TITLE
chore: increase mixer disk size default to 40GB + make it a var

### DIFF
--- a/terraform/aws/instances.tf
+++ b/terraform/aws/instances.tf
@@ -412,7 +412,7 @@ resource "aws_instance" "mixer" {
   }
 
   root_block_device {
-    volume_size = 40
+    volume_size = var.mixer_size
     volume_type = var.volume_type
   }
 

--- a/terraform/aws/instances.tf
+++ b/terraform/aws/instances.tf
@@ -412,7 +412,7 @@ resource "aws_instance" "mixer" {
   }
 
   root_block_device {
-    volume_size = 15
+    volume_size = 40
     volume_type = var.volume_type
   }
 

--- a/terraform/aws/variables.tf
+++ b/terraform/aws/variables.tf
@@ -271,3 +271,8 @@ variable "create_eip" {
   type        = bool
   default     = true
 }
+
+variable "mixer_size" {
+  description = "Size of the mixer disk in GB"
+  default     = "40"
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
Increase mixer disk size - logs/chain were taking the full disk with only 15GB


## What was done?
Increase size

## How Has This Been Tested?
testnet


## Breaking Changes
None


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone
