### PR TITLE
fix: metrics dns name not set correctly

### DIFF
--- a/terraform/aws/main.tf
+++ b/terraform/aws/main.tf
@@ -293,7 +293,7 @@ resource "aws_route53_record" "metrics" {
   name    = "metrics.${var.public_network_name}.networks.${var.main_domain}"
   type    = "CNAME"
   ttl     = "300"
-  records = [aws_elb.web[count.index].dns_name]
+  records = [aws_instance.metrics[count.index].public_ip]
   count   = length(var.main_domain) > 1 ? 1 : 0
 }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented

DNS record ` "metrics.${var.public_network_name}.networks.${var.main_domain}"` is not created successfully.


## What was done?

fixed what looks like a copy-paste bug


## How Has This Been Tested?

NOT TESTED 

## Breaking Changes

None

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone
