### PR TITLE
fix: fake latency is not affecting hp masternodes

### DIFF
--- a/ansible/deploy.yml
+++ b/ansible/deploy.yml
@@ -3,7 +3,7 @@
 # Bootstrap
 
 - name: Remove latency on masternodes before deployment starts
-  hosts: masternodes
+  hosts: masternodes,hp_masternodes
   become: true
   roles:
     - remove_fake_latency
@@ -294,7 +294,7 @@
     - role: mn_protx_diff
 
 - name: Set up fake latency on masternodes
-  hosts: masternodes
+  hosts: hp_masternodes,masternodes
   become: true
   roles:
     - role: add_fake_latency

--- a/ansible/roles/add_fake_latency/tasks/main.yml
+++ b/ansible/roles/add_fake_latency/tasks/main.yml
@@ -3,4 +3,4 @@
 - name: Generate fake latency
   ansible.builtin.command: tc qdisc replace dev ens5 root netem delay {{ masternode_network_latency_max }}ms {{ masternode_network_latency_min }}ms 25%
   register: my_output
-  changed_when: my_output.rc != 0
+  changed_when: my_output.rc == 0


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fake latency role is not affecting hp master nodes. Also change status isn't correct.

## What was done?
<!--- Describe your changes in detail -->
- Run fake latency on hp master nodes as well
- Fixed changed_when

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Deploy on taomeo

## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->
None

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [x] I have assigned this pull request to a milestone
