### PR TITLE
fix: Finer control of dashd_debug and drive debugging

### DIFF
--- a/ansible/roles/dashmate/templates/dashmate.json.j2
+++ b/ansible/roles/dashmate/templates/dashmate.json.j2
@@ -402,7 +402,7 @@
               }
             },
             "log": {
-              "level": "{{ tenderdash_log_level }}",
+              "level": "{{ node.get('tenderdash_debug', tenderdash_log_level) }}",
               "format": "json",
               "path": "{{ dashmate_logs_dir }}/tenderdash.log"
             },

--- a/ansible/roles/dashmate/templates/dashmate.json.j2
+++ b/ansible/roles/dashmate/templates/dashmate.json.j2
@@ -137,7 +137,7 @@
         "log": {
           "filePath": "{{ dashmate_logs_dir }}/core.log",
           "debug": {
-            "enabled": {% if dashd_debug == 1 %}true{% else %}false{% endif %},
+            "enabled": {% if dashd_debug == 1 or node.get('dashd_debug', 0) == 1%}true{% else %}false{% endif %},
             "ips": false,
             "sourceLocations": false,
             "threadNames": false,
@@ -248,7 +248,7 @@
         "drive": {
           "abci": {
             "docker": {
-              "image": "{{ drive_image }}",
+              "image": "{% if node.get('drive_debug', 0) == 1 %}{{ drive_image }}-debug{% else %}{{ drive_image }}{% endif %}",
               "build": {
                 "enabled": false,
                 "context": "{{ dashmate_source_dir }}",
@@ -283,8 +283,8 @@
               }{% endif %}
             },
             "grovedbVisualizer": {
-              "enabled": {% if platform_drive_grovedb_visualizer_enabled %}true{% else %}false{% endif %},
-              "host": "{{ private_ip }}",
+              "enabled": {% if node.get('drive_debug', 0) == 1 %}true{% else %}false{% endif %},
+              "host": "{% if node.get('drive_debug', 0) == 1 %}0.0.0.0{% else %}{{private_ip}}{% endif %}",
               "port": {{ platform_drive_grovedb_visualizer_port }}
             },
             "tokioConsole": {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
Individual control of a node's debug level, there are 3 options we can add under a node now:
* dashd_debug (can be set to 0 or 1)
* drive_debug (can be set to 0 or 1, it will use the corresponding debug image of drive and enable visualizer on nodes with debug on)
* tenderdash_debug (passed straight to tenderdash, ie info, debug, trace)



## What was done?
Changed dashmate template to use additional vars from the yml file


## How Has This Been Tested?
Testnet on devnet 


## Breaking Changes
None, if these vars are not defined it will use global vars as before. This PR is backwards compatible


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ x] I have performed a self-review of my own code
- [x ] I have commented my code, particularly in hard-to-understand areas
- [ x] I have added or updated relevant unit/integration/functional/e2e tests
- [x ] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone
