### PR TITLE
Confirmation for any testnet destroy operation

### DIFF
--- a/bin/destroy
+++ b/bin/destroy
@@ -39,6 +39,16 @@ if [ $EXIT ]; then
     exit 1
 fi
 
+# Confirmation for destroy command on testnet with -t=all
+if [[ $NETWORK_NAME == "testnet" ]]; then
+    echo "⚠️⚠️⚠️  You are about to destroy the entire 'testnet' environment. This will cause untold damage to platform and most likely make keys irrevocable - testnet platform will STALL forever ⚠️⚠️⚠️"
+    read -p "Are you sure you want to proceed? Type 'I solemnly swear I know what I am doing and take on all responsibility' to continue: " confirmation
+    if [[ $confirmation != "I solemnly swear I know what I am doing and take on all responsibility" ]]; then
+        echo "Operation cancelled."
+        exit 1
+    fi
+fi
+
 . ./lib/cli/init.sh
 . ./lib/cli/terraform.sh
 . ./lib/cli/ansible.sh


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
Confirmation before issuing any destroy command on testnet, explaining that platform will likely stall forever if it is run.


## What was done?
Confirmation + a way to bypass it with the prompt


## How Has This Been Tested?
./bin/destroy -t=all testnet


## Breaking Changes
None

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [x] I have assigned this pull request to a milestone
