### PR TITLE
Chore: Reconfigure insight

### DIFF
--- a/ansible/group_vars/all
+++ b/ansible/group_vars/all
@@ -109,6 +109,7 @@ faucet_minimum_payout: 10
 faucet_maximum_payout: 10
 faucet_payout_threshold: 100
 faucet_payout_interval: "5m"
+faucet_port: 3003
 
 # Example faucet address/privkey (provide your own in network config)
 #faucet_address: yhvXpqQjfN9S4j5mBKbxeGxiETJrrLETg5

--- a/ansible/roles/insight/templates/docker-compose.yml.j2
+++ b/ansible/roles/insight/templates/docker-compose.yml.j2
@@ -18,7 +18,7 @@ services:
     depends_on:
       - insight
     ports:
-      - {{ insight_port }}:{{ insight_port }}
+      - 80:80
     volumes:
       - {{ insight_path }}/insight-proxy-nginx.conf:/etc/nginx/conf.d/default.conf
 

--- a/ansible/roles/insight/templates/insight-proxy-nginx.conf.j2
+++ b/ansible/roles/insight/templates/insight-proxy-nginx.conf.j2
@@ -1,17 +1,25 @@
 server {
-    listen 3001;
+    listen 80;
 
-    location / {
-        proxy_pass http://{{ private_ip }}:3002;
-        proxy_set_header Host $host;
-        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-        proxy_set_header X-Real-IP $remote_addr;
+    location = / {
+        return 301 /insight/;
     }
 
-    location /insight-api-dash {
+    # 1) Pass /insight-api requests directly
+    location ^~ /insight-api {
         proxy_pass http://{{ private_ip }}:3002/insight-api/;
-        proxy_set_header Host $host;
-        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header Host              $host;
+        proxy_set_header X-Forwarded-For   $proxy_add_x_forwarded_for;
+        proxy_set_header X-Real-IP         $remote_addr;
+    }
+
+    # 2) Rewrite everything else under /insight
+    location / {
+        
+        # Then proxy it to the same app
+        proxy_pass http://{{ private_ip }}:3002;
+        proxy_set_header Host              $host;
+        proxy_set_header X-Forwarded-For   $proxy_add_x_forwarded_for;
+        proxy_set_header X-Real-IP         $remote_addr;
     }
 }

--- a/ansible/roles/multifaucet/templates/docker-compose.yml.j2
+++ b/ansible/roles/multifaucet/templates/docker-compose.yml.j2
@@ -40,7 +40,7 @@ services:
     volumes:
       - ./config:/var/www/html/config/
     ports:
-      - 80:80
+      - {{ faucet_port }}:80
 
 volumes:
   mysql:

--- a/terraform/aws/instances.tf
+++ b/terraform/aws/instances.tf
@@ -314,6 +314,7 @@ resource "aws_instance" "hp_masternode_arm" {
 
   subnet_id = element(aws_subnet.public.*.id, count.index)
 
+  
   root_block_device {
     volume_size = var.hpmn_node_disk_size
     volume_type = var.volume_type
@@ -332,7 +333,8 @@ resource "aws_instance" "hp_masternode_arm" {
   }
 
   lifecycle {
-    ignore_changes = [ami]
+    ignore_changes = [ami, root_block_device[0].volume_size]
+    
   }
 
 }

--- a/terraform/aws/main.tf
+++ b/terraform/aws/main.tf
@@ -105,14 +105,14 @@ resource "aws_elb" "web" {
   ]
 
   listener {
-    instance_port     = 80
+    instance_port     = 3003
     instance_protocol = "http"
     lb_port           = 80
     lb_protocol       = "http"
   }
 
   listener {
-    instance_port      = 80
+    instance_port      = 3003
     instance_protocol  = "http"
     lb_port            = 443
     lb_protocol        = "https"
@@ -122,7 +122,7 @@ resource "aws_elb" "web" {
   health_check {
     healthy_threshold   = 2
     interval            = 20
-    target              = "HTTP:80/"
+    target              = "HTTP:3003/"
     timeout             = 3
     unhealthy_threshold = 2
   }

--- a/terraform/aws/main.tf
+++ b/terraform/aws/main.tf
@@ -105,14 +105,14 @@ resource "aws_elb" "web" {
   ]
 
   listener {
-    instance_port     = 3003
+    instance_port     = var.faucet_port
     instance_protocol = "http"
     lb_port           = 80
     lb_protocol       = "http"
   }
 
   listener {
-    instance_port      = 3003
+    instance_port      = var.faucet_port
     instance_protocol  = "http"
     lb_port            = 443
     lb_protocol        = "https"
@@ -122,7 +122,7 @@ resource "aws_elb" "web" {
   health_check {
     healthy_threshold   = 2
     interval            = 20
-    target              = "HTTP:3003/"
+    target              = "HTTP:${var.faucet_port}/"
     timeout             = 3
     unhealthy_threshold = 2
   }
@@ -149,14 +149,14 @@ resource "aws_elb" "insight" {
   ]
 
   listener {
-    instance_port     = 80
+    instance_port     = var.insight_port
     instance_protocol = "http"
     lb_port           = 80
     lb_protocol       = "http"
   }
 
   listener {
-    instance_port      = 80
+    instance_port      = var.insight_port
     instance_protocol  = "http"
     lb_port            = 443
     lb_protocol        = "https"

--- a/terraform/aws/main.tf
+++ b/terraform/aws/main.tf
@@ -105,33 +105,18 @@ resource "aws_elb" "web" {
   ]
 
   listener {
-    instance_port     = var.faucet_port
+    instance_port     = 80
     instance_protocol = "http"
-    lb_port           = var.faucet_port
+    lb_port           = 80
     lb_protocol       = "http"
   }
 
   listener {
-    instance_port      = var.faucet_port
+    instance_port      = 80
     instance_protocol  = "http"
-    lb_port            = var.faucet_https_port
+    lb_port            = 443
     lb_protocol        = "https"
     ssl_certificate_id = aws_acm_certificate_validation.faucet.certificate_arn
-  }
-
-  listener {
-    instance_port     = var.insight_port
-    instance_protocol = "http"
-    lb_port           = var.insight_port
-    lb_protocol       = "http"
-  }
-
-  listener {
-    instance_port      = var.insight_port
-    instance_protocol  = "http"
-    lb_port            = var.insight_https_port
-    lb_protocol        = "https"
-    ssl_certificate_id = aws_acm_certificate_validation.insight.certificate_arn
   }
 
   health_check {
@@ -144,6 +129,50 @@ resource "aws_elb" "web" {
 
   tags = {
     Name        = "dn-${terraform.workspace}-web"
+    DashNetwork = terraform.workspace
+  }
+}
+
+resource "aws_elb" "insight" {
+  name = "${var.public_network_name}-insight"
+
+  subnets = aws_subnet.public.*.id
+
+  count = var.web_count >= 1 ? 1 : 0
+
+  security_groups = [
+    aws_security_group.elb.id,
+  ]
+
+  instances = [
+    aws_instance.web[0].id,
+  ]
+
+  listener {
+    instance_port     = 80
+    instance_protocol = "http"
+    lb_port           = 80
+    lb_protocol       = "http"
+  }
+
+  listener {
+    instance_port      = 80
+    instance_protocol  = "http"
+    lb_port            = 443
+    lb_protocol        = "https"
+    ssl_certificate_id = aws_acm_certificate_validation.insight.certificate_arn
+  }
+
+  health_check {
+    healthy_threshold   = 2
+    interval            = 20
+    target              = "HTTP:80/insight-api/status"
+    timeout             = 3
+    unhealthy_threshold = 2
+  }
+
+  tags = {
+    Name        = "dn-${terraform.workspace}-insight"
     DashNetwork = terraform.workspace
   }
 }
@@ -283,7 +312,7 @@ resource "aws_route53_record" "insight" {
   name    = "insight.${var.public_network_name}.${var.main_domain}"
   type    = "CNAME"
   ttl     = "300"
-  records = [aws_elb.web[count.index].dns_name]
+  records = [aws_elb.insight[count.index].dns_name]
 
   count = length(var.main_domain) > 1 ? 1 : 0
 }

--- a/terraform/aws/security_groups.tf
+++ b/terraform/aws/security_groups.tf
@@ -164,8 +164,8 @@ resource "aws_security_group" "http" {
   vpc_id      = aws_vpc.default.id
 
   ingress {
-    from_port   = 80
-    to_port     = 80
+    from_port   = 3003
+    to_port     = 3003
     protocol    = "tcp"
     description = "Faucet"
 
@@ -175,16 +175,28 @@ resource "aws_security_group" "http" {
     ])
   }
 
+  # Insight Explorer
   ingress {
-    from_port   = var.insight_port
-    to_port     = var.insight_port
+    from_port   = 80
+    to_port     = 80
     protocol    = "tcp"
     description = "Insight Explorer"
 
-    cidr_blocks = flatten([
-      aws_subnet.public.*.cidr_block,
-      "${aws_eip.vpn[0].public_ip}/32",
-    ])
+    cidr_blocks = [
+      "0.0.0.0/0",
+    ]
+  }
+
+  # Insight Explorer HTTPS
+  ingress {
+    from_port   = 443
+    to_port     = 443
+    protocol    = "tcp"
+    description = "Insight Explorer HTTPS"
+
+    cidr_blocks = [
+      "0.0.0.0/0",
+    ]
   }
 
   tags = {

--- a/terraform/aws/security_groups.tf
+++ b/terraform/aws/security_groups.tf
@@ -302,7 +302,7 @@ resource "aws_security_group" "hp_masternode" {
     description = "GroveDB visualizer"
 
     cidr_blocks = [
-      "10.0.0.0/16",
+      "0.0.0.0/0",
     ]
   }
 
@@ -422,8 +422,8 @@ resource "aws_security_group" "elb" {
 
   # Insight Explorer
   ingress {
-    from_port   = var.insight_port
-    to_port     = var.insight_port
+    from_port   = 80
+    to_port     = 80
     protocol    = "tcp"
     description = "Insight Explorer"
 
@@ -434,8 +434,8 @@ resource "aws_security_group" "elb" {
 
   # Insight Explorer HTTPS
   ingress {
-    from_port   = var.insight_https_port
-    to_port     = var.insight_https_port
+    from_port   = 443
+    to_port     = 443
     protocol    = "tcp"
     description = "Insight Explorer HTTPS"
 

--- a/terraform/aws/security_groups.tf
+++ b/terraform/aws/security_groups.tf
@@ -164,8 +164,8 @@ resource "aws_security_group" "http" {
   vpc_id      = aws_vpc.default.id
 
   ingress {
-    from_port   = 3003
-    to_port     = 3003
+    from_port   = var.faucet_port
+    to_port     = var.faucet_port
     protocol    = "tcp"
     description = "Faucet"
 
@@ -177,8 +177,8 @@ resource "aws_security_group" "http" {
 
   # Insight Explorer
   ingress {
-    from_port   = 80
-    to_port     = 80
+    from_port   = var.insight_port
+    to_port     = var.insight_port
     protocol    = "tcp"
     description = "Insight Explorer"
 
@@ -189,8 +189,8 @@ resource "aws_security_group" "http" {
 
   # Insight Explorer HTTPS
   ingress {
-    from_port   = 443
-    to_port     = 443
+    from_port   = var.insight_https_port
+    to_port     = var.insight_https_port
     protocol    = "tcp"
     description = "Insight Explorer HTTPS"
 
@@ -446,8 +446,8 @@ resource "aws_security_group" "elb" {
 
   # Insight Explorer HTTPS
   ingress {
-    from_port   = 443
-    to_port     = 443
+    from_port   = var.insight_https_port
+    to_port     = var.insight_https_port
     protocol    = "tcp"
     description = "Insight Explorer HTTPS"
 

--- a/terraform/aws/variables.tf
+++ b/terraform/aws/variables.tf
@@ -28,12 +28,12 @@ variable "faucet_https_port" {
 
 variable "insight_port" {
   description = "Insight port"
-  default     = 3001
+  default     = 80
 }
 
 variable "insight_https_port" {
   description = "Insight HTTPS port"
-  default     = 3002
+  default     = 443
 }
 
 variable "ssh_port" {

--- a/terraform/aws/variables.tf
+++ b/terraform/aws/variables.tf
@@ -18,12 +18,12 @@ variable "dashd_zmq_port" {
 
 variable "faucet_port" {
   description = "Faucet port"
-  default     = 80
+  default     = 3003
 }
 
 variable "faucet_https_port" {
   description = "Faucet HTTPS port"
-  default     = 443
+  default     = 3004
 }
 
 variable "insight_port" {
@@ -243,7 +243,7 @@ variable "load_test_instance_size" {
 
 variable "metrics_root_disk_size" {
   description = "Default disk size for load testing nodes"
-  default     = 20
+  default     = 40
 }
 
 variable "metrics_instance_type" {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
Insight has been reconfigured, so it's no longer on 3001/3002 and redirects properly using the insight_proxy container. 


## What was done?
Changes to terraform to ensure we now use port 80/443 for insight
Split into two LB's (one for insight, one for faucet) 
Changes to security groups


## How Has This Been Tested?
Deployed to testnet already


## Breaking Changes
Anyone using the previous URL must update their scripts


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [x] I have assigned this pull request to a milestone
