### PR TITLE
[infra] update dashmate configs and Fix ZeroSSL undefined variable ch…

### DIFF
--- a/ansible/group_vars/all
+++ b/ansible/group_vars/all
@@ -41,6 +41,7 @@ tenderdash_compose_path: '{{ dashd_home }}/{{ tenderdash_compose_project_name }}
 
 # DAPI
 dapi_image: dashpay/dapi
+rs_dapi_image: dashpay/rs-dapi
 
 # Gateway
 gateway_image: envoyproxy/envoy

--- a/ansible/roles/dashmate/tasks/ssl/zerossl.yml
+++ b/ansible/roles/dashmate/tasks/ssl/zerossl.yml
@@ -101,19 +101,25 @@
   community.aws.ssm_parameter:
     name: '{{ dashmate_zerossl_ssm_path }}-id'
     value: '{{ dashmate_zerossl_config_certificate_id }}'
-  when: dashmate_zerossl_ssm_certificate_id != dashmate_zerossl_config_certificate_id
+  when:
+    - dashmate_zerossl_config_certificate_id is defined
+    - dashmate_zerossl_ssm_certificate_id != dashmate_zerossl_config_certificate_id
 
 - name: Read new generated ZeroSSL private key file to variable
   ansible.builtin.slurp:
     src: '{{ dashmate_zerossl_keys_path }}/{{ dashmate_zerossl_private_key_file_name }}'
   register: dashmate_zerossl_private_key_file
-  when: dashmate_zerossl_ssm_certificate_id != dashmate_zerossl_config_certificate_id
+  when:
+    - dashmate_zerossl_config_certificate_id is defined
+    - dashmate_zerossl_ssm_certificate_id != dashmate_zerossl_config_certificate_id
 
 - name: Read new generated ZeroSSL CSR file to variable
   ansible.builtin.slurp:
     src: '{{ dashmate_zerossl_keys_path }}/{{ dashmate_zerossl_csr_file_name }}'
   register: dashmate_zerossl_csr_file
-  when: dashmate_zerossl_ssm_certificate_id != dashmate_zerossl_config_certificate_id
+  when:
+    - dashmate_zerossl_config_certificate_id is defined
+    - dashmate_zerossl_ssm_certificate_id != dashmate_zerossl_config_certificate_id
 
 - name: Set new generated ZeroSSL CSR and private key files
   ansible.builtin.set_fact:
@@ -122,7 +128,9 @@
         content: '{{ dashmate_zerossl_private_key_file.content | b64decode }}'
       - name: "{{ dashmate_zerossl_csr_file_name }}"
         content: '{{ dashmate_zerossl_csr_file.content | b64decode }}'
-  when: dashmate_zerossl_ssm_certificate_id != dashmate_zerossl_config_certificate_id
+  when:
+    - dashmate_zerossl_config_certificate_id is defined
+    - dashmate_zerossl_ssm_certificate_id != dashmate_zerossl_config_certificate_id
 
 - name: Update ZeroSSL private key and CSR files in AWS SSM parameter store
   delegate_to: localhost
@@ -131,4 +139,6 @@
     name: '{{ dashmate_zerossl_ssm_path }}-{{ item.name }}'
     value: '{{ item.content }}'
   loop: '{{ dashmate_zerossl_files }}'
-  when: dashmate_zerossl_ssm_certificate_id != dashmate_zerossl_config_certificate_id
+  when:
+    - dashmate_zerossl_config_certificate_id is defined
+    - dashmate_zerossl_ssm_certificate_id != dashmate_zerossl_config_certificate_id

--- a/ansible/roles/dashmate/templates/dashmate.json.j2
+++ b/ansible/roles/dashmate/templates/dashmate.json.j2
@@ -144,6 +144,10 @@
             "includeOnly": [],
             "exclude": []
           }
+        },
+        "zmq": {
+          "host": "0.0.0.0",
+          "port": {{ dashd_zmq_port }}
         }
       },
       "platform": {
@@ -228,6 +232,9 @@
           }
         },
         "dapi": {
+          "deprecated": {
+            "enabled": false
+          },
           "api": {
             "docker": {
               "image": "{{ dapi_image }}",
@@ -237,11 +244,35 @@
               "build": {
                 "enabled": false,
                 "context": "{{ dashmate_source_dir }}",
-                "dockerFile": "{{ dashmate_source_dir }}/packages/dapi/Dockerfile",
-                "target": ""
+                "dockerFile": "{{ dashmate_source_dir }}/Dockerfile",
+                "target": "dapi"
               }
             },
             "waitForStResultTimeout": {{ dashmate_platform_dapi_api_wait_for_st_result_timeout }}
+          },
+          "rsDapi": {
+            "docker": {
+              "image": "{% if rs_dapi_image is defined %}{{ rs_dapi_image }}{% else %}{{ dapi_image | regex_replace('^dashpay/dapi:', 'dashpay/rs-dapi:') }}{% endif %}",
+              "deploy": {
+                "replicas": {{ dashmate_platform_dapi_api_docker_deploy_replicas }}
+              },
+              "build": {
+                "enabled": false,
+                "context": "{{ dashmate_source_dir }}",
+                "dockerFile": "{{ dashmate_source_dir }}/Dockerfile",
+                "target": "rs-dapi"
+              }
+            },
+            "metrics": {
+              "host": "127.0.0.1",
+              "port": 9091
+            },
+            "logs": {
+              "level": "debug",
+              "jsonFormat": false,
+              "accessLogPath": null,
+              "accessLogFormat": "combined"
+            }
           }
         },
         "drive": {


### PR DESCRIPTION
  - Add zmq configuration to core config (required by new dashmate schema)
  - Add rsDapi configuration with metrics and logging
  - Add deprecated flag for legacy DAPI control
  - Fix ZeroSSL undefined variable checks in deployment tasks
  - Add rs_dapi_image variable to support separate rs-dapi image versioning
  
  Test completed on Testnet: Deployed on HPMN-16 and HPMN-21

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* New Features
  * Added rsDapi service configuration with deploy settings, metrics (127.0.0.1:9091), and enhanced logging options.
  * Exposed Core ZMQ settings (host 0.0.0.0 with configurable port).

* Refactor
  * Updated DAPI build configuration (Dockerfile/target adjustments).
  * Introduced rsDapi alongside existing services and related sections.

* Bug Fixes
  * Improved ZeroSSL task conditions to avoid unnecessary certificate operations when configuration is unset or unchanged.

* Chores
  * Added configurable image selection for rsDapi.
  * Marked legacy DAPI block as deprecated (disabled by default).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->