### PR TITLE
Added  checks in the dashmate template before accessing node properties

### DIFF
--- a/ansible/roles/dashmate/templates/dashmate.json.j2
+++ b/ansible/roles/dashmate/templates/dashmate.json.j2
@@ -136,7 +136,7 @@
         "log": {
           "filePath": "{{ dashmate_logs_dir }}/core.log",
           "debug": {
-            "enabled": {% if dashd_debug == 1 or node.get('dashd_debug', 0) == 1%}true{% else %}false{% endif %},
+            "enabled": {% if dashd_debug == 1 or (node is defined and node.get('dashd_debug', 0) == 1)%}true{% else %}false{% endif %},
             "ips": false,
             "sourceLocations": false,
             "threadNames": false,
@@ -278,7 +278,7 @@
         "drive": {
           "abci": {
             "docker": {
-              "image": "{% if node.get('drive_debug', 0) == 1 %}{{ drive_image }}-debug{% else %}{{ drive_image }}{% endif %}",
+              "image": "{% if node is defined and node.get('drive_debug', 0) == 1 %}{{ drive_image }}-debug{% else %}{{ drive_image }}{% endif %}",
               "build": {
                 "enabled": false,
                 "context": "{{ dashmate_source_dir }}",
@@ -313,8 +313,8 @@
               }{% endif %}
             },
             "grovedbVisualizer": {
-              "enabled": {% if node.get('drive_debug', 0) == 1 %}true{% else %}false{% endif %},
-              "host": "{% if node.get('drive_debug', 0) == 1 %}0.0.0.0{% else %}{{private_ip}}{% endif %}",
+              "enabled": {% if node is defined and node.get('drive_debug', 0) == 1 %}true{% else %}false{% endif %},
+              "host": "{% if node is defined and node.get('drive_debug', 0) == 1 %}0.0.0.0{% else %}{{private_ip}}{% endif %}",
               "port": {{ platform_drive_grovedb_visualizer_port }}
             },
             "tokioConsole": {
@@ -432,14 +432,14 @@
               }
             },
             "log": {
-              "level": "{{ node.get('tenderdash_debug', tenderdash_log_level) }}",
+              "level": "{{ node.get('tenderdash_debug', tenderdash_log_level) if node is defined else tenderdash_log_level }}",
               "format": "json",
               "path": "{{ dashmate_logs_dir }}/tenderdash.log"
             },
             "moniker": "{{ inventory_hostname }}",
             "node": {
-              "id": "{{ node.node_key.id }}",
-              "key": "{{ node.node_key.private_key }}"
+              "id": "{{ node.node_key.id if node is defined else '' }}",
+              "key": "{{ node.node_key.private_key if node is defined else '' }}"
             },
             "genesis": {
               "chain_id": "dash-{{ ( 'devnet-' + dash_devnet_name if dash_network == 'devnet' else dash_network ) if tenderdash_chain_id is not defined else tenderdash_chain_id }}",


### PR DESCRIPTION
  ## Problem
Deployment was failing with `AnsibleUndefinedVariable: 'node' is undefined` errors on certain HP masternodes (e.g., hp-masternode-3, 4, 6) that don't have the `node` variable defined in their inventory.

  ## Solution
  Added `node is defined` checks in the dashmate template before accessing node properties:

  1. **Core log debug** (line 139): Check node before accessing `dashd_debug`
  2. **Drive image selection** (line 281): Check node before accessing `drive_debug`
  3. **GroveDB Visualizer** (lines 316-317): Check node before accessing `drive_debug` for visualizer config
  4. **Tenderdash log level** (line 435): Add fallback to default log level when node undefined
  5. **Tenderdash node keys** (lines 441-442): Add empty string fallbacks for node key id and private key

  ## Testing
  - Deployment now succeeds on nodes both with and without `node` variable defined
  - Template renders correctly with appropriate defaults when `node` is undefined

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced configuration template with safety checks to gracefully handle undefined variables, ensuring proper fallback values are used instead of causing potential runtime errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->