### PR TITLE
[infra] relax ELB health check settings for faucet and insight

### DIFF
--- a/terraform/aws/main.tf
+++ b/terraform/aws/main.tf
@@ -135,10 +135,10 @@ resource "aws_elb" "web" {
 
   health_check {
     healthy_threshold   = 2
-    interval            = 20
+    interval            = 60
     target              = "HTTP:${var.faucet_port}/"
-    timeout             = 3
-    unhealthy_threshold = 2
+    timeout             = 10
+    unhealthy_threshold = 5
   }
 
   tags = {
@@ -179,10 +179,10 @@ resource "aws_elb" "insight" {
 
   health_check {
     healthy_threshold   = 2
-    interval            = 20
+    interval            = 60
     target              = "HTTP:80/insight-api/status"
-    timeout             = 3
-    unhealthy_threshold = 2
+    timeout             = 10
+    unhealthy_threshold = 5
   }
 
   tags = {


### PR DESCRIPTION
  - Increase timeout from 3s to 10s
  - Increase interval from 20s to 60s  
  - Increase unhealthy threshold from 2 to 5

  This prevents intermittent 503s during high load or slow responses.
  
  

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated load balancer health check parameters to enhance service resilience. Extended health check intervals to 60 seconds with longer timeout windows and increased failure tolerance thresholds.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->