### PR TITLE
fix(ansible): use default stdout callback and fix letsencrypt conversion

### DIFF
--- a/ansible/ansible.cfg
+++ b/ansible/ansible.cfg
@@ -4,7 +4,8 @@ host_key_checking = False
 gather_timeout = 20
 timeout = 50
 forks = 50
-stdout_callback = yaml
+stdout_callback = default
+result_format = yaml
 bin_ansible_callbacks = True
 
 [ssh_connection]

--- a/bin/convert-to-letsencrypt
+++ b/bin/convert-to-letsencrypt
@@ -77,13 +77,26 @@ CONVERT_CMD=$(cat <<'REMOTE_EOF'
 set -e
 echo "[$(hostname)] Starting Let's Encrypt conversion..."
 
-# Set the SSL provider to letsencrypt
-sudo -u dashmate bash -c 'cd /home/dashmate && dashmate config set platform.gateway.ssl.provider letsencrypt'
-echo "[$(hostname)] Set SSL provider to letsencrypt"
-
-# Set the email
-sudo -u dashmate bash -c 'cd /home/dashmate && dashmate config set platform.gateway.ssl.providerConfigs.letsencrypt.email EMAIL_PLACEHOLDER'
-echo "[$(hostname)] Set letsencrypt email"
+# Patch config.json to add letsencrypt providerConfig if missing and set provider
+CONFIG_FILE="/home/dashmate/.dashmate/config.json"
+sudo python3 -c "
+import json
+with open('$CONFIG_FILE') as f:
+    c = json.load(f)
+for name, cfg in c.get('configs', {}).items():
+    ssl = cfg.get('platform', {}).get('gateway', {}).get('ssl', {})
+    if ssl:
+        ssl['provider'] = 'letsencrypt'
+        pc = ssl.setdefault('providerConfigs', {})
+        if 'letsencrypt' not in pc:
+            pc['letsencrypt'] = {'email': 'EMAIL_PLACEHOLDER'}
+        else:
+            pc['letsencrypt'].setdefault('email', 'EMAIL_PLACEHOLDER')
+with open('$CONFIG_FILE', 'w') as f:
+    json.dump(c, f, indent=2)
+"
+sudo chown dashmate:dashmate "$CONFIG_FILE"
+echo "[$(hostname)] Patched config.json with letsencrypt provider and email"
 
 # Render config to pick up changes
 sudo -u dashmate bash -c 'cd /home/dashmate && dashmate config render'
@@ -131,7 +144,7 @@ for line in "${MATCHES[@]}"; do
       -o ConnectTimeout=10 \
       -i "$SSH_KEY" \
       "${ANSIBLE_USER}@${ANSIBLE_HOST}" \
-      "bash -c '${CONVERT_CMD}'" \
+      "${CONVERT_CMD}" \
       > "$LOG_FILE" 2>&1 &
 
   PIDS+=("$!:$NODE_NAME:$LOG_FILE")

--- a/bin/convert-to-letsencrypt
+++ b/bin/convert-to-letsencrypt
@@ -79,8 +79,9 @@ echo "[$(hostname)] Starting Let's Encrypt conversion..."
 
 # Patch config.json to add letsencrypt providerConfig if missing and set provider
 CONFIG_FILE="/home/dashmate/.dashmate/config.json"
-sudo python3 -c "
-import json
+sudo LE_EMAIL="$LE_EMAIL" python3 -c "
+import json, os
+email = os.environ['LE_EMAIL']
 with open('$CONFIG_FILE') as f:
     c = json.load(f)
 for name, cfg in c.get('configs', {}).items():
@@ -89,9 +90,9 @@ for name, cfg in c.get('configs', {}).items():
         ssl['provider'] = 'letsencrypt'
         pc = ssl.setdefault('providerConfigs', {})
         if 'letsencrypt' not in pc:
-            pc['letsencrypt'] = {'email': 'EMAIL_PLACEHOLDER'}
+            pc['letsencrypt'] = {'email': email}
         else:
-            pc['letsencrypt'].setdefault('email', 'EMAIL_PLACEHOLDER')
+            pc['letsencrypt'].setdefault('email', email)
 with open('$CONFIG_FILE', 'w') as f:
     json.dump(c, f, indent=2)
 "
@@ -113,9 +114,6 @@ echo "[$(hostname)] Restarted platform services"
 echo "[$(hostname)] Conversion complete!"
 REMOTE_EOF
 )
-
-# Replace email placeholder
-CONVERT_CMD="${CONVERT_CMD//EMAIL_PLACEHOLDER/$EMAIL}"
 
 PIDS=()
 LOG_DIR=$(mktemp -d)
@@ -144,7 +142,7 @@ for line in "${MATCHES[@]}"; do
       -o ConnectTimeout=10 \
       -i "$SSH_KEY" \
       "${ANSIBLE_USER}@${ANSIBLE_HOST}" \
-      "${CONVERT_CMD}" \
+      "export LE_EMAIL=$(printf '%q' "$EMAIL"); ${CONVERT_CMD}" \
       > "$LOG_FILE" 2>&1 &
 
   PIDS+=("$!:$NODE_NAME:$LOG_FILE")


### PR DESCRIPTION
## Summary
- Switch ansible `stdout_callback` from `yaml` to `default` with `result_format=yaml` to fix output rendering issues
- Update `convert-to-letsencrypt` script to directly patch `config.json` via python3 instead of using `dashmate config set`, which avoids failures when the `letsencrypt` providerConfig key doesn't exist yet

## Test plan
- [ ] Run ansible playbook and verify output renders correctly
- [ ] Run `convert-to-letsencrypt` on a node that has no existing letsencrypt config

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive infrastructure operations guide covering testnet architecture, command usage, troubleshooting, deployment workflows, and node management procedures.

* **Bug Fixes**
  * Improved Let's Encrypt certificate configuration with enhanced reliability and clearer progress indicators.

* **Chores**
  * Updated deployment automation configuration for improved system data collection during setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->