### PR TITLE
feat(infra): add status dashboard for devnet deployments

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,6 @@ node_modules
 # VS Code
 .vscode
 networks
+
+# Local docs
+INFRA.MD

--- a/ansible/deploy.yml
+++ b/ansible/deploy.yml
@@ -241,10 +241,13 @@
 - name: Deploy status monitoring to masternodes
   hosts: masternodes,hp_masternodes
   become: true
+  gather_facts: false
+  strategy: free
   roles:
     - status_monitoring
   tags:
     - full_deploy
+    - dashmate_deploy
     - status_dashboard
 
 - name: Set up wallets

--- a/ansible/deploy.yml
+++ b/ansible/deploy.yml
@@ -230,11 +230,22 @@
       dashd_zmq: true
       dashd_listen: true
     - insight
+    - role: status_dashboard
+      when: dash_network == "devnet"
     - core_filebeat
     - metricbeat
   tags:
     - full_deploy
     - web
+
+- name: Deploy status monitoring to masternodes
+  hosts: masternodes,hp_masternodes
+  become: true
+  roles:
+    - status_monitoring
+  tags:
+    - full_deploy
+    - status_dashboard
 
 - name: Set up wallets
   hosts: wallet_nodes

--- a/ansible/roles/status_dashboard/defaults/main.yml
+++ b/ansible/roles/status_dashboard/defaults/main.yml
@@ -1,0 +1,7 @@
+---
+
+status_dashboard_image: dashpay/status:latest
+status_dashboard_port: 3010
+status_dashboard_path: "{{ dashd_home }}/status_dashboard"
+status_dashboard_poll_interval: 10000
+status_dashboard_poll_concurrency: 20

--- a/ansible/roles/status_dashboard/tasks/main.yml
+++ b/ansible/roles/status_dashboard/tasks/main.yml
@@ -1,0 +1,32 @@
+---
+
+- name: Create status dashboard directory
+  ansible.builtin.file:
+    path: "{{ status_dashboard_path }}"
+    state: directory
+    recurse: true
+
+- name: Copy inventory file for status dashboard
+  ansible.builtin.copy:
+    src: "{{ inventory_file }}"
+    dest: "{{ status_dashboard_path }}/inventory"
+    mode: "0644"
+
+- name: Copy SSH deploy key for status dashboard
+  ansible.builtin.copy:
+    src: "{{ lookup('env', 'PRIVATE_KEY_PATH') | default('~/.ssh/evo-app-deploy.rsa', true) }}"
+    dest: "{{ status_dashboard_path }}/ssh_key"
+    mode: "0600"
+
+- name: Deploy status dashboard docker-compose
+  ansible.builtin.template:
+    src: docker-compose.yml.j2
+    dest: "{{ status_dashboard_path }}/docker-compose.yml"
+    mode: "0644"
+
+- name: Start status dashboard
+  community.docker.docker_compose_v2:
+    project_src: "{{ status_dashboard_path }}"
+    state: present
+    pull: always
+    recreate: always

--- a/ansible/roles/status_dashboard/tasks/main.yml
+++ b/ansible/roles/status_dashboard/tasks/main.yml
@@ -17,6 +17,9 @@
     src: "{{ lookup('env', 'PRIVATE_KEY_PATH') | default('~/.ssh/evo-app-deploy.rsa', true) }}"
     dest: "{{ status_dashboard_path }}/ssh_key"
     mode: "0600"
+    owner: root
+    group: root
+  no_log: true
 
 - name: Deploy status dashboard docker-compose
   ansible.builtin.template:
@@ -28,5 +31,5 @@
   community.docker.docker_compose_v2:
     project_src: "{{ status_dashboard_path }}"
     state: present
-    pull: always
-    recreate: always
+    pull: "{{ 'always' if (force_dashmate_reinstall | default(false) or not (skip_dashmate_image_update | default(false))) else 'policy' }}"
+    recreate: "{{ 'always' if (force_dashmate_rebuild | default(false)) else 'auto' }}"

--- a/ansible/roles/status_dashboard/templates/docker-compose.yml.j2
+++ b/ansible/roles/status_dashboard/templates/docker-compose.yml.j2
@@ -1,0 +1,22 @@
+version: '3'
+
+services:
+  status:
+    image: {{ status_dashboard_image }}
+    container_name: status_dashboard
+    restart: always
+    ports:
+      - {{ status_dashboard_port }}:3001
+    environment:
+      - INVENTORY_PATH=/app/data/inventory
+      - SSH_KEY_PATH=/app/data/ssh_key
+      - SSH_USER=ubuntu
+      - SSH_COMMAND=/usr/local/bin/dashmon-check
+      - SSH_PORT=22
+      - POLL_INTERVAL_MS={{ status_dashboard_poll_interval }}
+      - POLL_CONCURRENCY={{ status_dashboard_poll_concurrency }}
+      - PORT=3001
+      - NETWORK_NAME={{ dash_network_name }}
+    volumes:
+      - {{ status_dashboard_path }}/inventory:/app/data/inventory:ro
+      - {{ status_dashboard_path }}/ssh_key:/app/data/ssh_key:ro

--- a/ansible/roles/status_monitoring/files/dashmon-check.sh
+++ b/ansible/roles/status_monitoring/files/dashmon-check.sh
@@ -7,7 +7,7 @@ set -euo pipefail
 
 if [[ -f /home/dashmate/.dashmate/config.json ]]; then
     # HP masternode: dashmate status as the dashmate user
-    sudo -u dashmate dashmate status 2>&1
+    sudo -u dashmate dashmate status 2>&1 || true
     echo "===SYSMETRICS==="
 else
     # Regular masternode: dash-cli as the ubuntu user

--- a/ansible/roles/status_monitoring/files/dashmon-check.sh
+++ b/ansible/roles/status_monitoring/files/dashmon-check.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+# /usr/local/bin/dashmon-check
+# Read-only monitoring script for the dash testnet status dashboard.
+# Deployed to all masternodes. This is the forced command for the dashmon SSH key.
+# Detects HP vs regular masternode by checking for dashmate configuration.
+set -euo pipefail
+
+if [[ -f /home/dashmate/.dashmate/config.json ]]; then
+    # HP masternode: dashmate status as the dashmate user
+    sudo -u dashmate dashmate status 2>&1
+    echo "===SYSMETRICS==="
+else
+    # Regular masternode: dash-cli as the ubuntu user
+    echo "===BLOCKCHAIN==="
+    sudo -u ubuntu dash-cli getblockchaininfo 2>&1 || true
+    echo "===MASTERNODE==="
+    sudo -u ubuntu dash-cli masternode status 2>&1 || true
+    echo "===SYSMETRICS==="
+fi
+
+# System metrics (no privileges needed)
+head -1 /proc/loadavg
+nproc
+free -m | grep Mem
+df -h / | tail -1

--- a/ansible/roles/status_monitoring/tasks/main.yml
+++ b/ansible/roles/status_monitoring/tasks/main.yml
@@ -1,0 +1,9 @@
+---
+
+- name: Copy dashmon-check monitoring script
+  ansible.builtin.copy:
+    src: dashmon-check.sh
+    dest: /usr/local/bin/dashmon-check
+    mode: "0755"
+    owner: root
+    group: root

--- a/terraform/aws/main.tf
+++ b/terraform/aws/main.tf
@@ -331,6 +331,87 @@ resource "aws_route53_record" "insight" {
   count = length(var.main_domain) > 1 ? 1 : 0
 }
 
+resource "aws_elb" "status" {
+  name = "${var.public_network_name}-status"
+
+  subnets = aws_subnet.public.*.id
+
+  count = var.web_count >= 1 ? 1 : 0
+
+  security_groups = [
+    aws_security_group.elb.id,
+  ]
+
+  instances = [
+    aws_instance.web[0].id,
+  ]
+
+  listener {
+    instance_port     = var.status_port
+    instance_protocol = "http"
+    lb_port           = 80
+    lb_protocol       = "http"
+  }
+
+  listener {
+    instance_port      = var.status_port
+    instance_protocol  = "http"
+    lb_port            = 443
+    lb_protocol        = "https"
+    ssl_certificate_id = aws_acm_certificate_validation.status.certificate_arn
+  }
+
+  health_check {
+    healthy_threshold   = 2
+    interval            = 60
+    target              = "HTTP:${var.status_port}/api/health"
+    timeout             = 10
+    unhealthy_threshold = 5
+  }
+
+  tags = {
+    Name        = "dn-${terraform.workspace}-status"
+    DashNetwork = terraform.workspace
+  }
+}
+
+resource "aws_acm_certificate" "status" {
+  domain_name       = "status.${var.public_network_name}.${var.main_domain}"
+  validation_method = "DNS"
+}
+
+resource "aws_route53_record" "status_validation" {
+  for_each = {
+    for dvo in aws_acm_certificate.status.domain_validation_options : dvo.domain_name => {
+      name   = dvo.resource_record_name
+      record = dvo.resource_record_value
+      type   = dvo.resource_record_type
+    }
+  }
+
+  zone_id         = data.aws_route53_zone.main_domain[0].zone_id
+  allow_overwrite = true
+  name            = each.value.name
+  records         = [each.value.record]
+  ttl             = 60
+  type            = each.value.type
+}
+
+resource "aws_acm_certificate_validation" "status" {
+  certificate_arn         = aws_acm_certificate.status.arn
+  validation_record_fqdns = [for record in aws_route53_record.status_validation : record.fqdn]
+}
+
+resource "aws_route53_record" "status" {
+  zone_id = data.aws_route53_zone.main_domain[count.index].zone_id
+  name    = "status.${var.public_network_name}.${var.main_domain}"
+  type    = "CNAME"
+  ttl     = "300"
+  records = [aws_elb.status[count.index].dns_name]
+
+  count = length(var.main_domain) > 1 ? 1 : 0
+}
+
 resource "aws_route53_record" "metrics" {
   zone_id = data.aws_route53_zone.main_domain[0].zone_id
   name    = "metrics.${var.public_network_name}.networks.${var.main_domain}"

--- a/terraform/aws/security_groups.tf
+++ b/terraform/aws/security_groups.tf
@@ -211,17 +211,13 @@ resource "aws_security_group" "http" {
     ipv6_cidr_blocks = var.enable_ipv6 ? ["::/0"] : []
   }
 
-  # Status Dashboard
+  # Status Dashboard (ELB only)
   ingress {
-    from_port   = var.status_port
-    to_port     = var.status_port
-    protocol    = "tcp"
-    description = "Status Dashboard"
-
-    cidr_blocks = flatten([
-      aws_subnet.public.*.cidr_block,
-      "${aws_eip.vpn[0].public_ip}/32",
-    ])
+    from_port       = var.status_port
+    to_port         = var.status_port
+    protocol        = "tcp"
+    description     = "Status Dashboard"
+    security_groups = [aws_security_group.elb.id]
   }
 
   tags = {

--- a/terraform/aws/security_groups.tf
+++ b/terraform/aws/security_groups.tf
@@ -207,8 +207,21 @@ resource "aws_security_group" "http" {
     cidr_blocks = [
       "0.0.0.0/0",
     ]
-    
+
     ipv6_cidr_blocks = var.enable_ipv6 ? ["::/0"] : []
+  }
+
+  # Status Dashboard
+  ingress {
+    from_port   = var.status_port
+    to_port     = var.status_port
+    protocol    = "tcp"
+    description = "Status Dashboard"
+
+    cidr_blocks = flatten([
+      aws_subnet.public.*.cidr_block,
+      "${aws_eip.vpn[0].public_ip}/32",
+    ])
   }
 
   tags = {

--- a/terraform/aws/variables.tf
+++ b/terraform/aws/variables.tf
@@ -36,6 +36,11 @@ variable "insight_https_port" {
   default     = 443
 }
 
+variable "status_port" {
+  description = "Status dashboard port"
+  default     = 3010
+}
+
 variable "ssh_port" {
   description = "SSH port"
   default     = 22


### PR DESCRIPTION
## Summary
- Adds automatic status dashboard deployment to web-1 for devnets
- Accessible at `https://status.<devnet-name>.networks.dash.org`
- Uses the `dashpay/status` Docker image (built via CI on [dashpay/status](https://github.com/dashpay/status))

### Terraform
- New Classic ELB with ACM certificate for the `status.*` subdomain
- Route53 CNAME record pointing to the status ELB
- Security group ingress rule for port 3010

### Ansible
- **`status_monitoring` role**: deploys the `dashmon-check.sh` monitoring script to all masternodes and HP masternodes
- **`status_dashboard` role**: pulls and runs the status Docker container on web-1, with the inventory file and SSH deploy key mounted as volumes
- Conditionally enabled only for devnet networks (`when: dash_network == "devnet"`)

### Usage
```bash
# Included automatically in full devnet deploy
./bin/deploy devnet-<name>

# Deploy status dashboard only (on existing devnet)
./bin/deploy -p --tags=status_dashboard devnet-<name>
```

## Test plan
- [ ] Deploy a devnet and verify status page comes up at `https://status.<devnet>.networks.dash.org`
- [ ] Verify all masternodes and HP masternodes appear on the dashboard
- [ ] Verify real-time SSE updates are working
- [ ] Verify standalone `--tags=status_dashboard` deployment works

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive Testnet Infrastructure Operations Guide covering architecture, deployment procedures, and troubleshooting.

* **New Features**
  * Introduced status dashboard for monitoring masternode health and network metrics.
  * Added automated status monitoring across all masternodes with real-time system metrics.

* **Chores**
  * Enhanced infrastructure automation to support status dashboard and monitoring deployment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->