### PR TITLE
feat(terraform): add BYOIP support for all devnet instances

### DIFF
--- a/terraform/aws/ansible_inventory_output.tf
+++ b/terraform/aws/ansible_inventory_output.tf
@@ -5,7 +5,7 @@ locals {
       {
         index      = n + 1
         name       = element(aws_instance.web.*.tags.Hostname, n)
-        public_ip  = element(aws_instance.web.*.public_ip, n)
+        public_ip  = var.byoip_pool_id != "" ? element(aws_eip.web_eip.*.public_ip, n) : element(aws_instance.web.*.public_ip, n)
         private_ip = element(aws_instance.web.*.private_ip, n)
       }
     )
@@ -29,7 +29,7 @@ locals {
       {
         index      = n + 1
         name       = element(aws_instance.dashd_wallet.*.tags.Hostname, n)
-        public_ip  = element(aws_instance.dashd_wallet.*.public_ip, n)
+        public_ip  = var.byoip_pool_id != "" ? element(aws_eip.wallet_eip.*.public_ip, n) : element(aws_instance.dashd_wallet.*.public_ip, n)
         private_ip = element(aws_instance.dashd_wallet.*.private_ip, n)
       }
     )
@@ -53,7 +53,7 @@ locals {
       {
         index      = n + 1
         name       = element(aws_instance.seed_node.*.tags.Hostname, n)
-        public_ip  = element(aws_instance.seed_node.*.public_ip, n)
+        public_ip  = var.byoip_pool_id != "" ? element(aws_eip.seed_eip.*.public_ip, n) : element(aws_instance.seed_node.*.public_ip, n)
         private_ip = element(aws_instance.seed_node.*.private_ip, n)
       }
     )
@@ -89,7 +89,7 @@ locals {
       {
         index      = n + 1
         name       = element(aws_instance.miner.*.tags.Hostname, n)
-        public_ip  = element(aws_instance.miner.*.public_ip, n)
+        public_ip  = var.byoip_pool_id != "" ? element(aws_eip.miner_eip.*.public_ip, n) : element(aws_instance.miner.*.public_ip, n)
         private_ip = element(aws_instance.miner.*.private_ip, n)
       }
     )
@@ -101,7 +101,7 @@ locals {
       {
         index      = n + 1
         name       = element(aws_instance.masternode_amd.*.tags.Hostname, n)
-        public_ip  = element(aws_instance.masternode_amd.*.public_ip, n)
+        public_ip  = var.byoip_pool_id != "" ? element(aws_eip.mn_amd_eip.*.public_ip, n) : element(aws_instance.masternode_amd.*.public_ip, n)
         private_ip = element(aws_instance.masternode_amd.*.private_ip, n)
       }
     )
@@ -113,7 +113,7 @@ locals {
       {
         index      = n + 1
         name       = element(aws_instance.masternode_arm.*.tags.Hostname, n)
-        public_ip  = element(aws_instance.masternode_arm.*.public_ip, n)
+        public_ip  = var.byoip_pool_id != "" ? element(aws_eip.mn_arm_eip.*.public_ip, n) : element(aws_instance.masternode_arm.*.public_ip, n)
         private_ip = element(aws_instance.masternode_arm.*.private_ip, n)
       }
     )
@@ -127,7 +127,7 @@ locals {
       {
         index      = n + 1
         name       = element(aws_instance.hp_masternode_amd.*.tags.Hostname, n)
-        public_ip = var.create_eip ? element(aws_eip.hpmn_amd_eip.*.public_ip, n) : element(aws_instance.hp_masternode_amd.*.public_ip, n)
+        public_ip = (var.create_eip || var.byoip_pool_id != "") ? element(aws_eip.hpmn_amd_eip.*.public_ip, n) : element(aws_instance.hp_masternode_amd.*.public_ip, n)
         private_ip = element(aws_instance.hp_masternode_amd.*.private_ip, n)
       }
     )
@@ -139,7 +139,7 @@ locals {
       {
         index      = n + 1
         name       = element(aws_instance.hp_masternode_arm.*.tags.Hostname, n)
-        public_ip  = var.create_eip ? element(aws_eip.hpmn_arm_eip.*.public_ip, n) : element(aws_instance.hp_masternode_arm.*.public_ip, n)
+        public_ip  = (var.create_eip || var.byoip_pool_id != "") ? element(aws_eip.hpmn_arm_eip.*.public_ip, n) : element(aws_instance.hp_masternode_arm.*.public_ip, n)
         private_ip = element(aws_instance.hp_masternode_arm.*.private_ip, n)
       }
     )

--- a/terraform/aws/instances.tf
+++ b/terraform/aws/instances.tf
@@ -239,19 +239,21 @@ resource "aws_instance" "masternode_arm" {
 }
 
 resource "aws_eip" "hpmn_arm_eip" {
-  instance = null
-  count = var.create_eip ? var.hp_masternode_arm_count : 0
+  instance         = null
+  count            = (var.create_eip || var.byoip_pool_id != "") ? var.hp_masternode_arm_count : 0
+  public_ipv4_pool = var.byoip_pool_id != "" ? var.byoip_pool_id : null
   tags = {
-    Name        = "dn-${terraform.workspace}-hp-masternode-arm-${count.index+1}"
+    Name        = "dn-${terraform.workspace}-hp-masternode-arm-${count.index + 1}"
     DashNetwork = terraform.workspace
   }
 }
 
 resource "aws_eip" "hpmn_amd_eip" {
-  instance = null
-  count = var.create_eip ? var.hp_masternode_amd_count : 0
+  instance         = null
+  count            = (var.create_eip || var.byoip_pool_id != "") ? var.hp_masternode_amd_count : 0
+  public_ipv4_pool = var.byoip_pool_id != "" ? var.byoip_pool_id : null
   tags = {
-    Name        = "dn-${terraform.workspace}-hp-masternode-amd-${count.index+1}"
+    Name        = "dn-${terraform.workspace}-hp-masternode-amd-${count.index + 1}"
     DashNetwork = terraform.workspace
   }
 }
@@ -340,17 +342,109 @@ resource "aws_instance" "hp_masternode_arm" {
 }
 
 resource "aws_eip_association" "arm_eip_assoc" {
-  count = var.create_eip ? var.hp_masternode_arm_count : 0
+  count = (var.create_eip || var.byoip_pool_id != "") ? var.hp_masternode_arm_count : 0
 
   instance_id   = aws_instance.hp_masternode_arm[count.index].id
   allocation_id = aws_eip.hpmn_arm_eip[count.index].id
 }
 
 resource "aws_eip_association" "amd_eip_assoc" {
-  count = var.create_eip ? var.hp_masternode_amd_count : 0
+  count = (var.create_eip || var.byoip_pool_id != "") ? var.hp_masternode_amd_count : 0
 
   instance_id   = aws_instance.hp_masternode_amd[count.index].id
   allocation_id = aws_eip.hpmn_amd_eip[count.index].id
+}
+
+# BYOIP EIPs for non-HPMN instance types
+
+resource "aws_eip" "mn_amd_eip" {
+  count            = var.byoip_pool_id != "" ? var.masternode_amd_count : 0
+  public_ipv4_pool = var.byoip_pool_id
+  tags = {
+    Name        = "dn-${terraform.workspace}-masternode-amd-${count.index + 1}"
+    DashNetwork = terraform.workspace
+  }
+}
+
+resource "aws_eip_association" "mn_amd_eip_assoc" {
+  count         = var.byoip_pool_id != "" ? var.masternode_amd_count : 0
+  instance_id   = aws_instance.masternode_amd[count.index].id
+  allocation_id = aws_eip.mn_amd_eip[count.index].id
+}
+
+resource "aws_eip" "mn_arm_eip" {
+  count            = var.byoip_pool_id != "" ? var.masternode_arm_count : 0
+  public_ipv4_pool = var.byoip_pool_id
+  tags = {
+    Name        = "dn-${terraform.workspace}-masternode-arm-${count.index + 1}"
+    DashNetwork = terraform.workspace
+  }
+}
+
+resource "aws_eip_association" "mn_arm_eip_assoc" {
+  count         = var.byoip_pool_id != "" ? var.masternode_arm_count : 0
+  instance_id   = aws_instance.masternode_arm[count.index].id
+  allocation_id = aws_eip.mn_arm_eip[count.index].id
+}
+
+resource "aws_eip" "web_eip" {
+  count            = var.byoip_pool_id != "" ? var.web_count : 0
+  public_ipv4_pool = var.byoip_pool_id
+  tags = {
+    Name        = "dn-${terraform.workspace}-web-${count.index + 1}"
+    DashNetwork = terraform.workspace
+  }
+}
+
+resource "aws_eip_association" "web_eip_assoc" {
+  count         = var.byoip_pool_id != "" ? var.web_count : 0
+  instance_id   = aws_instance.web[count.index].id
+  allocation_id = aws_eip.web_eip[count.index].id
+}
+
+resource "aws_eip" "wallet_eip" {
+  count            = var.byoip_pool_id != "" ? var.wallet_count : 0
+  public_ipv4_pool = var.byoip_pool_id
+  tags = {
+    Name        = "dn-${terraform.workspace}-dashd-wallet-${count.index + 1}"
+    DashNetwork = terraform.workspace
+  }
+}
+
+resource "aws_eip_association" "wallet_eip_assoc" {
+  count         = var.byoip_pool_id != "" ? var.wallet_count : 0
+  instance_id   = aws_instance.dashd_wallet[count.index].id
+  allocation_id = aws_eip.wallet_eip[count.index].id
+}
+
+resource "aws_eip" "seed_eip" {
+  count            = var.byoip_pool_id != "" ? var.seed_count : 0
+  public_ipv4_pool = var.byoip_pool_id
+  tags = {
+    Name        = "dn-${terraform.workspace}-seed-${count.index + 1}"
+    DashNetwork = terraform.workspace
+  }
+}
+
+resource "aws_eip_association" "seed_eip_assoc" {
+  count         = var.byoip_pool_id != "" ? var.seed_count : 0
+  instance_id   = aws_instance.seed_node[count.index].id
+  allocation_id = aws_eip.seed_eip[count.index].id
+}
+
+resource "aws_eip" "miner_eip" {
+  count            = var.byoip_pool_id != "" ? var.miner_count : 0
+  public_ipv4_pool = var.byoip_pool_id
+  tags = {
+    Name        = "dn-${terraform.workspace}-miner-${count.index + 1}"
+    DashNetwork = terraform.workspace
+  }
+}
+
+resource "aws_eip_association" "miner_eip_assoc" {
+  count         = var.byoip_pool_id != "" ? var.miner_count : 0
+  instance_id   = aws_instance.miner[count.index].id
+  allocation_id = aws_eip.miner_eip[count.index].id
 }
 
 

--- a/terraform/aws/main.tf
+++ b/terraform/aws/main.tf
@@ -357,18 +357,18 @@ locals {
 # shuffle hpmn ips only
 resource "random_shuffle" "dns_ips" {
   input = concat(
-    var.create_eip ? aws_eip.hpmn_arm_eip.*.public_ip : aws_instance.hp_masternode_arm.*.public_ip,
-    var.create_eip ? aws_eip.hpmn_amd_eip.*.public_ip : aws_instance.hp_masternode_amd.*.public_ip
+    (var.create_eip || var.byoip_pool_id != "") ? aws_eip.hpmn_arm_eip.*.public_ip : aws_instance.hp_masternode_arm.*.public_ip,
+    (var.create_eip || var.byoip_pool_id != "") ? aws_eip.hpmn_amd_eip.*.public_ip : aws_instance.hp_masternode_amd.*.public_ip
   )
   result_count = length(
     concat(
-      var.create_eip ? aws_eip.hpmn_arm_eip.*.public_ip : aws_instance.hp_masternode_arm.*.public_ip,
-      var.create_eip ? aws_eip.hpmn_amd_eip.*.public_ip : aws_instance.hp_masternode_amd.*.public_ip
+      (var.create_eip || var.byoip_pool_id != "") ? aws_eip.hpmn_arm_eip.*.public_ip : aws_instance.hp_masternode_arm.*.public_ip,
+      (var.create_eip || var.byoip_pool_id != "") ? aws_eip.hpmn_amd_eip.*.public_ip : aws_instance.hp_masternode_amd.*.public_ip
     )
   ) > local.dns_record_length ? local.dns_record_length : length(
     concat(
-      var.create_eip ? aws_eip.hpmn_arm_eip.*.public_ip : aws_instance.hp_masternode_arm.*.public_ip,
-      var.create_eip ? aws_eip.hpmn_amd_eip.*.public_ip : aws_instance.hp_masternode_amd.*.public_ip
+      (var.create_eip || var.byoip_pool_id != "") ? aws_eip.hpmn_arm_eip.*.public_ip : aws_instance.hp_masternode_arm.*.public_ip,
+      (var.create_eip || var.byoip_pool_id != "") ? aws_eip.hpmn_amd_eip.*.public_ip : aws_instance.hp_masternode_amd.*.public_ip
     )
   )
 }
@@ -426,7 +426,8 @@ resource "aws_eip" "vpn" {
 
   count = var.vpn_enabled ? 1 : 0
 
-  instance = aws_instance.vpn[0].id
+  instance         = aws_instance.vpn[0].id
+  public_ipv4_pool = var.byoip_pool_id != "" ? var.byoip_pool_id : null
 
   tags = {
     Name        = "dn-${terraform.workspace}-vpn"

--- a/terraform/aws/services_output.tf
+++ b/terraform/aws/services_output.tf
@@ -111,7 +111,7 @@ locals {
             ),
           ),
           "{{ip}}",
-          element(aws_instance.masternode_amd.*.public_ip, n),
+          var.byoip_pool_id != "" ? element(aws_eip.mn_amd_eip.*.public_ip, n) : element(aws_instance.masternode_amd.*.public_ip, n),
         )
         internal_services = replace(
           chomp(
@@ -126,7 +126,7 @@ locals {
             ),
           ),
           "{{ip}}",
-          element(aws_instance.masternode_amd.*.public_ip, n),
+          var.byoip_pool_id != "" ? element(aws_eip.mn_amd_eip.*.public_ip, n) : element(aws_instance.masternode_amd.*.public_ip, n),
         )
         service_logs = chomp(
           join(
@@ -157,7 +157,7 @@ locals {
             ),
           ),
           "{{ip}}",
-          element(aws_instance.masternode_arm.*.public_ip, n),
+          var.byoip_pool_id != "" ? element(aws_eip.mn_arm_eip.*.public_ip, n) : element(aws_instance.masternode_arm.*.public_ip, n),
         )
         internal_services = replace(
           chomp(
@@ -172,7 +172,7 @@ locals {
             ),
           ),
           "{{ip}}",
-          element(aws_instance.masternode_arm.*.public_ip, n),
+          var.byoip_pool_id != "" ? element(aws_eip.mn_arm_eip.*.public_ip, n) : element(aws_instance.masternode_arm.*.public_ip, n),
         )
         service_logs = chomp(
           join(
@@ -207,7 +207,7 @@ hp_masternodes_amd = [
           ),
         ),
         "{{ip}}",
-        var.create_eip ? element(aws_eip.hpmn_amd_eip.*.public_ip, n) : element(aws_instance.hp_masternode_amd.*.public_ip, n),
+        (var.create_eip || var.byoip_pool_id != "") ? element(aws_eip.hpmn_amd_eip.*.public_ip, n) : element(aws_instance.hp_masternode_amd.*.public_ip, n),
       )
       internal_services = replace(
         chomp(
@@ -224,7 +224,7 @@ hp_masternodes_amd = [
           ),
         ),
         "{{ip}}",
-        var.create_eip ? element(aws_eip.hpmn_amd_eip.*.public_ip, n) : element(aws_instance.hp_masternode_amd.*.public_ip, n),
+        (var.create_eip || var.byoip_pool_id != "") ? element(aws_eip.hpmn_amd_eip.*.public_ip, n) : element(aws_instance.hp_masternode_amd.*.public_ip, n),
       )
       service_logs = chomp(
         join(
@@ -263,7 +263,7 @@ hp_masternodes_amd = [
           ),
         ),
         "{{ip}}",
-        var.create_eip ? element(aws_eip.hpmn_arm_eip.*.public_ip, n) : element(aws_instance.hp_masternode_arm.*.public_ip, n),
+        (var.create_eip || var.byoip_pool_id != "") ? element(aws_eip.hpmn_arm_eip.*.public_ip, n) : element(aws_instance.hp_masternode_arm.*.public_ip, n),
       )
       internal_services = replace(
         chomp(
@@ -280,7 +280,7 @@ hp_masternodes_amd = [
           ),
         ),
         "{{ip}}",
-        var.create_eip ? element(aws_eip.hpmn_arm_eip.*.public_ip, n) : element(aws_instance.hp_masternode_arm.*.public_ip, n),
+        (var.create_eip || var.byoip_pool_id != "") ? element(aws_eip.hpmn_arm_eip.*.public_ip, n) : element(aws_instance.hp_masternode_arm.*.public_ip, n),
       )
       service_logs = chomp(
         join(
@@ -311,7 +311,7 @@ hp_masternodes_amd = [
         external_services = replace(
           chomp(join("", [local.service_ssh])),
           "{{ip}}",
-          element(aws_instance.dashd_wallet.*.public_ip, n),
+          var.byoip_pool_id != "" ? element(aws_eip.wallet_eip.*.public_ip, n) : element(aws_instance.dashd_wallet.*.public_ip, n),
         )
         internal_services = replace(
           chomp(
@@ -326,7 +326,7 @@ hp_masternodes_amd = [
             ),
           ),
           "{{ip}}",
-          element(aws_instance.dashd_wallet.*.public_ip, n),
+          var.byoip_pool_id != "" ? element(aws_eip.wallet_eip.*.public_ip, n) : element(aws_instance.dashd_wallet.*.public_ip, n),
         )
         service_logs = chomp(join("\n", ["   - dashd"]))
       }
@@ -381,7 +381,7 @@ hp_masternodes_amd = [
             ),
           ),
           "{{ip}}",
-          element(aws_instance.seed_node.*.public_ip, n),
+          var.byoip_pool_id != "" ? element(aws_eip.seed_eip.*.public_ip, n) : element(aws_instance.seed_node.*.public_ip, n),
         )
         internal_services = replace(
           chomp(
@@ -398,7 +398,7 @@ hp_masternodes_amd = [
             ),
           ),
           "{{ip}}",
-          element(aws_instance.seed_node.*.public_ip, n),
+          var.byoip_pool_id != "" ? element(aws_eip.seed_eip.*.public_ip, n) : element(aws_instance.seed_node.*.public_ip, n),
         )
         service_logs = chomp(join("\n", [
           "   - dashd",
@@ -422,7 +422,7 @@ hp_masternodes_amd = [
         external_services = replace(
           chomp(join("", [local.service_ssh])),
           "{{ip}}",
-          element(aws_instance.miner.*.public_ip, n),
+          var.byoip_pool_id != "" ? element(aws_eip.miner_eip.*.public_ip, n) : element(aws_instance.miner.*.public_ip, n),
         )
         internal_services = replace(
           chomp(
@@ -436,7 +436,7 @@ hp_masternodes_amd = [
             ),
           ),
           "{{ip}}",
-          element(aws_instance.miner.*.public_ip, n),
+          var.byoip_pool_id != "" ? element(aws_eip.miner_eip.*.public_ip, n) : element(aws_instance.miner.*.public_ip, n),
         )
         service_logs = chomp(join("\n", ["   - dashd"]))
       }

--- a/terraform/aws/variables.tf
+++ b/terraform/aws/variables.tf
@@ -288,3 +288,8 @@ variable "enable_ipv6" {
   default     = false
 }
 
+variable "byoip_pool_id" {
+  description = "IPAM pool ID for BYOIP address allocation. When set, all instances get EIPs from this pool."
+  default     = ""
+}
+


### PR DESCRIPTION
## Summary
- Adds `byoip_pool_id` terraform variable — when set, all instance types get EIPs allocated from the specified IPAM pool
- Creates EIP + association resources for masternodes (amd/arm), web, wallet, seed, and miner instances
- Updates existing HP masternode and VPN EIPs to use the pool when configured
- Updates inventory and services outputs to use EIP addresses when BYOIP is active

## Usage
In a devnet tfvars file:
```hcl
byoip_pool_id = "ipam-pool-0de83ed8bba5f9b48"
```
When not set (default `""`), behavior is unchanged.

## Test plan
- [ ] Deploy a devnet with `byoip_pool_id` set and verify all instances get 68.67.122.x addresses
- [ ] Deploy a devnet without `byoip_pool_id` and verify existing behavior is unchanged
- [ ] Verify inventory output contains correct EIP addresses

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Bring Your Own IP (BYOIP) support for all instance types. When configured with an IPAM pool ID, instances automatically use allocated addresses from your custom IP pool instead of default public addresses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->