### PR TITLE
  feat(infra): add HPMN backup workflow

### DIFF
--- a/.github/workflows/hpmn-backup.yml
+++ b/.github/workflows/hpmn-backup.yml
@@ -1,0 +1,123 @@
+name: Manual HP Masternode Backup
+
+on:
+  workflow_dispatch:
+    inputs:
+      network:
+        description: "Network to back up"
+        required: true
+        type: string
+        default: testnet
+      backup_label:
+        description: "Short label stamped into the S3 object path"
+        required: true
+        type: string
+      host_limit:
+        description: "Ansible limit expression (hp_masternodes or a single hp-masternode-N)"
+        required: true
+        type: string
+        default: hp_masternodes
+      install_backup_tooling:
+        description: "Install/update backup script prerequisites before running the backup"
+        required: true
+        type: boolean
+        default: false
+
+jobs:
+  backup:
+    name: Run HP masternode backup
+    runs-on: ubuntu-22.04
+    timeout-minutes: 90
+    env:
+      NETWORK_NAME: ${{ inputs.network }}
+      HOST_LIMIT: ${{ inputs.host_limit }}
+      HPMN_BACKUP_TRIGGER_LABEL: ${{ inputs.backup_label }}
+      HPMN_BACKUP_S3_BUCKET: ${{ vars.HPMN_BACKUP_S3_BUCKET }}
+      HPMN_BACKUP_S3_PREFIX: ${{ vars.HPMN_BACKUP_S3_PREFIX }}
+      HPMN_BACKUP_S3_SSE_MODE: ${{ vars.HPMN_BACKUP_S3_SSE_MODE }}
+      HPMN_BACKUP_S3_KMS_KEY_ID: ${{ secrets.HPMN_BACKUP_S3_KMS_KEY_ID }}
+      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+      AWS_REGION: ${{ secrets.AWS_REGION }}
+      ANSIBLE_HOST_KEY_CHECKING: "false"
+      ANSIBLE_CONFIG: ansible/ansible.cfg
+
+    steps:
+      - name: Checkout dash-network-deploy
+        uses: actions/checkout@v4
+
+      - name: Install controller dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y python3-pip python3-netaddr
+          python3 -m pip install --upgrade pip
+          python3 -m pip install ansible-core==2.16.3 jmespath
+
+      - name: Install Ansible roles and collections
+        run: |
+          ansible-galaxy install -r ansible/requirements.yml
+          mkdir -p ~/.ansible/roles
+          cp -r ansible/roles/* ~/.ansible/roles/
+
+      - name: Set up SSH keys
+        env:
+          DEPLOY_SERVER_KEY: ${{ secrets.DEPLOY_SERVER_KEY }}
+          EVO_APP_DEPLOY_KEY: ${{ secrets.EVO_APP_DEPLOY_KEY }}
+        run: |
+          mkdir -p ~/.ssh
+
+          printf '%s\n' "$DEPLOY_SERVER_KEY" > ~/.ssh/id_rsa
+          chmod 600 ~/.ssh/id_rsa
+          ssh-keygen -y -f ~/.ssh/id_rsa > ~/.ssh/id_rsa.pub
+          chmod 644 ~/.ssh/id_rsa.pub
+
+          printf '%s\n' "$EVO_APP_DEPLOY_KEY" > ~/.ssh/id_ed25519
+          chmod 600 ~/.ssh/id_ed25519
+
+          cat > ~/.ssh/config << 'EOL'
+          Host github.com
+            IdentityFile ~/.ssh/id_ed25519
+            StrictHostKeyChecking no
+
+          Host *
+            IdentityFile ~/.ssh/id_rsa
+            User ubuntu
+            StrictHostKeyChecking no
+            UserKnownHostsFile=/dev/null
+          EOL
+
+          chmod 600 ~/.ssh/config
+
+      - name: Clone network configs
+        run: |
+          rm -rf networks
+          git clone git@github.com:dashpay/dash-network-configs.git networks
+
+      - name: Validate network files and backup config
+        run: |
+          test -f "networks/${NETWORK_NAME}.inventory"
+          test -f "networks/${NETWORK_NAME}.yml"
+          test -n "$HPMN_BACKUP_S3_BUCKET"
+          test -n "$AWS_ACCESS_KEY_ID"
+          test -n "$AWS_SECRET_ACCESS_KEY"
+          test -n "$AWS_REGION"
+
+      - name: Install backup tooling on target HP masternodes
+        if: ${{ inputs.install_backup_tooling }}
+        run: |
+          ansible-playbook \
+            -i "networks/${NETWORK_NAME}.inventory" \
+            ansible/hpmn_backup_install.yml \
+            -e "@networks/${NETWORK_NAME}.yml" \
+            -e "dash_network_name=${NETWORK_NAME}" \
+            --limit "${HOST_LIMIT}"
+
+      - name: Trigger HP masternode backup
+        run: |
+          ansible-playbook \
+            -i "networks/${NETWORK_NAME}.inventory" \
+            ansible/hpmn_backup_run.yml \
+            -e "@networks/${NETWORK_NAME}.yml" \
+            -e "dash_network_name=${NETWORK_NAME}" \
+            -e "hpmn_backup_trigger_label=${HPMN_BACKUP_TRIGGER_LABEL}" \
+            --limit "${HOST_LIMIT}"

--- a/.github/workflows/hpmn-restore.yml
+++ b/.github/workflows/hpmn-restore.yml
@@ -1,45 +1,47 @@
-name: Manual HP Masternode Backup
+name: HP Masternode Restore
 
 on:
   workflow_dispatch:
     inputs:
       network:
-        description: "Network to back up"
+        description: "Network to restore"
         required: true
         type: string
         default: testnet
-      backup_label:
-        description: "Short label stamped into the S3 object path"
-        required: true
-        type: string
-      host_limit:
-        description: "Ansible limit expression (start with a single hp-masternode-N for validation)"
+      target_host:
+        description: "Single HP masternode host to restore"
         required: true
         type: string
         default: hp-masternode-1
-      batch_size:
-        description: "How many HPMNs may run backup concurrently"
+      restore_s3_uri:
+        description: "Full S3 URI of the backup archive to restore"
         required: true
         type: string
-        default: "5"
-      install_backup_tooling:
-        description: "Install/update backup script prerequisites before running the backup"
+      install_restore_tooling:
+        description: "Install/update restore prerequisites before running restore"
         required: true
         type: boolean
         default: false
+      start_services:
+        description: "Start dashmate services directly from the restore script"
+        required: true
+        type: boolean
+        default: false
+      finalize_restore:
+        description: "Run the finalize playbook after restore to regenerate host-specific config and start services"
+        required: true
+        type: boolean
+        default: true
 
 jobs:
-  backup:
-    name: Run HP masternode backup
+  restore:
+    name: Restore HP masternode
     runs-on: ubuntu-22.04
-    timeout-minutes: 90
+    timeout-minutes: 120
     env:
       NETWORK_NAME: ${{ inputs.network }}
-      HOST_LIMIT: ${{ inputs.host_limit }}
-      HPMN_BACKUP_TRIGGER_LABEL: ${{ inputs.backup_label }}
-      HPMN_BACKUP_S3_BUCKET: ${{ vars.HPMN_BACKUP_S3_BUCKET }}
-      HPMN_BACKUP_S3_PREFIX: ${{ vars.HPMN_BACKUP_S3_PREFIX }}
-      HPMN_BACKUP_S3_SSE_MODE: ${{ vars.HPMN_BACKUP_S3_SSE_MODE }}
+      TARGET_HOST: ${{ inputs.target_host }}
+      HPMN_RESTORE_S3_URI: ${{ inputs.restore_s3_uri }}
       AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
       AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
       AWS_SESSION_TOKEN: ${{ secrets.AWS_SESSION_TOKEN }}
@@ -98,48 +100,41 @@ jobs:
           rm -rf networks
           git clone git@github.com:dashpay/dash-network-configs.git networks
 
-      - name: Validate network files and backup config
+      - name: Validate restore config
         run: |
           test -f "networks/${NETWORK_NAME}.inventory"
           test -f "networks/${NETWORK_NAME}.yml"
-          test -n "$HPMN_BACKUP_S3_BUCKET"
-          test -n "$AWS_ACCESS_KEY_ID"
-          test -n "$AWS_SECRET_ACCESS_KEY"
+          test -n "$HPMN_RESTORE_S3_URI"
           test -n "$AWS_REGION"
-          case "${HPMN_BACKUP_S3_SSE_MODE:-AES256}" in
-            AES256)
-              ;;
-            aws:kms)
-              test -n "${{ secrets.HPMN_BACKUP_S3_KMS_KEY_ID }}"
-              ;;
-            *)
-              echo "Unsupported HPMN_BACKUP_S3_SSE_MODE: ${HPMN_BACKUP_S3_SSE_MODE}" >&2
-              exit 1
-              ;;
-          esac
 
-      - name: Install backup tooling on target HP masternodes
-        if: ${{ inputs.install_backup_tooling }}
+      - name: Install restore tooling on target host
+        if: ${{ inputs.install_restore_tooling }}
         run: |
           ansible-playbook \
             -i "networks/${NETWORK_NAME}.inventory" \
-            ansible/hpmn_backup_install.yml \
+            ansible/hpmn_restore_install.yml \
             -e "@networks/${NETWORK_NAME}.yml" \
             -e "dash_network_name=${NETWORK_NAME}" \
-            -e "hpmn_backup_install_serial=${{ inputs.batch_size }}" \
-            --limit "${HOST_LIMIT}"
+            --limit "${TARGET_HOST}"
 
-      - name: Trigger HP masternode backup
+      - name: Restore target host from S3 backup
         run: |
-          if [[ "${HPMN_BACKUP_S3_SSE_MODE:-AES256}" == "aws:kms" ]]; then
-            export HPMN_BACKUP_S3_KMS_KEY_ID="${{ secrets.HPMN_BACKUP_S3_KMS_KEY_ID }}"
-          fi
-
           ansible-playbook \
             -i "networks/${NETWORK_NAME}.inventory" \
-            ansible/hpmn_backup_run.yml \
+            ansible/hpmn_restore_run.yml \
             -e "@networks/${NETWORK_NAME}.yml" \
             -e "dash_network_name=${NETWORK_NAME}" \
-            -e "hpmn_backup_serial=${{ inputs.batch_size }}" \
-            -e "hpmn_backup_trigger_label=${HPMN_BACKUP_TRIGGER_LABEL}" \
-            --limit "${HOST_LIMIT}"
+            -e "hpmn_restore_s3_uri=${HPMN_RESTORE_S3_URI}" \
+            -e "hpmn_restore_start_services=${{ inputs.start_services }}" \
+            --limit "${TARGET_HOST}"
+
+      - name: Finalize restored target host
+        if: ${{ inputs.finalize_restore }}
+        run: |
+          ansible-playbook \
+            -i "networks/${NETWORK_NAME}.inventory" \
+            ansible/hpmn_restore_finalize.yml \
+            -e "@networks/${NETWORK_NAME}.yml" \
+            -e "dash_network_name=${NETWORK_NAME}" \
+            -e "dash_network=${NETWORK_NAME}" \
+            --limit "${TARGET_HOST}"

--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,5 @@ networks
 
 # Local docs
 INFRA.MD
+
+.codex

--- a/ansible/deploy.yml
+++ b/ansible/deploy.yml
@@ -51,6 +51,7 @@
     - name: Update apt cache and install jq
       ansible.builtin.apt:
         pkg:
+          - acl
           - jq
           - unzip
         update_cache: true

--- a/ansible/hpmn_backup_install.yml
+++ b/ansible/hpmn_backup_install.yml
@@ -1,0 +1,9 @@
+---
+- name: Install HP masternode backup tooling
+  hosts: hp_masternodes
+  become: true
+  gather_facts: true
+  roles:
+    - role: hpmn_backup
+  tags:
+    - hpmn_backup_install

--- a/ansible/hpmn_backup_install.yml
+++ b/ansible/hpmn_backup_install.yml
@@ -1,6 +1,7 @@
 ---
 - name: Install HP masternode backup tooling
   hosts: hp_masternodes
+  serial: "{{ hpmn_backup_install_serial | default(5) }}"
   become: true
   gather_facts: true
   roles:

--- a/ansible/hpmn_backup_run.yml
+++ b/ansible/hpmn_backup_run.yml
@@ -1,6 +1,7 @@
 ---
 - name: Run HP masternode backup on demand
   hosts: hp_masternodes
+  serial: "{{ hpmn_backup_serial | default(5) }}"
   become: true
   gather_facts: false
   tasks:

--- a/ansible/hpmn_backup_run.yml
+++ b/ansible/hpmn_backup_run.yml
@@ -1,0 +1,12 @@
+---
+- name: Run HP masternode backup on demand
+  hosts: hp_masternodes
+  become: true
+  gather_facts: false
+  tasks:
+    - name: Execute HP masternode backup role
+      ansible.builtin.include_role:
+        name: hpmn_backup
+        tasks_from: run
+  tags:
+    - hpmn_backup_run

--- a/ansible/hpmn_restore_finalize.yml
+++ b/ansible/hpmn_restore_finalize.yml
@@ -1,0 +1,25 @@
+---
+- name: Finalize restored HP masternode
+  hosts: hp_masternodes
+  serial: 1
+  become: true
+  gather_facts: false
+  pre_tasks:
+    - name: Enforce single-host finalize
+      ansible.builtin.assert:
+        that:
+          - ansible_play_hosts_all | length == 1
+        fail_msg: Finalize must target exactly one HP masternode host.
+      run_once: true
+
+    - name: Load HP masternode config for finalize
+      ansible.builtin.set_fact:
+        node: "{{ hp_masternodes[inventory_hostname] }}"
+      when: inventory_hostname in hp_masternodes
+
+  roles:
+    - role: dash_cli
+    - role: dashmate
+
+  tags:
+    - hpmn_restore_finalize

--- a/ansible/hpmn_restore_install.yml
+++ b/ansible/hpmn_restore_install.yml
@@ -1,0 +1,10 @@
+---
+- name: Install HP masternode restore tooling
+  hosts: hp_masternodes
+  serial: 1
+  become: true
+  gather_facts: true
+  roles:
+    - role: hpmn_restore
+  tags:
+    - hpmn_restore_install

--- a/ansible/hpmn_restore_run.yml
+++ b/ansible/hpmn_restore_run.yml
@@ -1,0 +1,20 @@
+---
+- name: Restore HP masternode from backup
+  hosts: hp_masternodes
+  serial: 1
+  become: true
+  gather_facts: false
+  pre_tasks:
+    - name: Enforce single-host restore
+      ansible.builtin.assert:
+        that:
+          - ansible_play_hosts_all | length == 1
+        fail_msg: Restore must target exactly one HP masternode host.
+      run_once: true
+  tasks:
+    - name: Execute HP masternode restore role
+      ansible.builtin.include_role:
+        name: hpmn_restore
+        tasks_from: run
+  tags:
+    - hpmn_restore_run

--- a/ansible/roles/dashmate/tasks/main.yml
+++ b/ansible/roles/dashmate/tasks/main.yml
@@ -133,7 +133,7 @@
     append: true
   when:
     - not (skip_dashmate_image_update | default(false))
-    - not dashmate_user_exists
+    - dashmate_user_exists
 
 # ============================================================================
 # EARLY PERMISSION FIXES - Ensure all dashmate directories have correct ownership
@@ -285,6 +285,7 @@
     - not (skip_dashmate_image_update | default(false))
     - dashmate_platform_gateway_ssl_provider == 'zerossl'
     - dashmate_config_result is defined
+    - dashmate_config_result.rc is defined
     - dashmate_config_result.rc == 0
 
 - name: Set ZeroSSL certificate ID from config
@@ -294,6 +295,7 @@
     - not (skip_dashmate_image_update | default(false))
     - dashmate_platform_gateway_ssl_provider == 'zerossl'
     - dashmate_config_result is defined
+    - dashmate_config_result.rc is defined
     - dashmate_config_result.rc == 0
     - dashmate_zerossl_id_result is defined
     - dashmate_zerossl_id_result.stdout != 'null'

--- a/ansible/roles/hpmn_backup/defaults/main.yml
+++ b/ansible/roles/hpmn_backup/defaults/main.yml
@@ -5,6 +5,7 @@ hpmn_backup_network_name: "{{ dash_network_name | default('testnet') }}"
 hpmn_backup_s3_prefix: hpmn-backups
 hpmn_backup_s3_sse_mode: AES256
 hpmn_backup_s3_kms_key_id: ""
+hpmn_backup_aws_region: ""
 hpmn_backup_static_paths:
   - /home/dashmate/.dashmate/config.json
   - "/home/dashmate/.dashmate/{{ hpmn_backup_network_name }}/platform/drive/tenderdash"

--- a/ansible/roles/hpmn_backup/defaults/main.yml
+++ b/ansible/roles/hpmn_backup/defaults/main.yml
@@ -12,6 +12,8 @@ hpmn_backup_static_paths:
   - "/home/dashmate/.dashmate/{{ hpmn_backup_network_name }}/platform/gateway/ssl"
 hpmn_backup_tenderdash_volume_candidates:
   - "/var/lib/docker/volumes/dashmate_{{ hpmn_backup_network_name }}_drive_tenderdash/_data"
+hpmn_backup_drive_abci_volume_candidates:
+  - "/var/lib/docker/volumes/dashmate_{{ hpmn_backup_network_name }}_drive_abci_data/_data"
 hpmn_backup_llmq_candidates:
   - "/var/lib/docker/volumes/dashmate_{{ hpmn_backup_network_name }}_core_data/_data/.dashcore/testnet3/llmq"
   - "/var/lib/docker/volumes/dashmate_{{ hpmn_backup_network_name }}_core_data/_data/.dashcore/{{ hpmn_backup_network_name }}/llmq"

--- a/ansible/roles/hpmn_backup/defaults/main.yml
+++ b/ansible/roles/hpmn_backup/defaults/main.yml
@@ -1,0 +1,20 @@
+---
+hpmn_backup_script_path: /usr/local/bin/hpmn-backup
+hpmn_backup_staging_dir: /var/tmp/hpmn-backup
+hpmn_backup_network_name: "{{ dash_network_name | default('testnet') }}"
+hpmn_backup_s3_prefix: hpmn-backups
+hpmn_backup_s3_sse_mode: AES256
+hpmn_backup_s3_kms_key_id: ""
+hpmn_backup_static_paths:
+  - /home/dashmate/.dashmate/config.json
+  - "/home/dashmate/.dashmate/{{ hpmn_backup_network_name }}/platform/drive/tenderdash"
+  - "/home/dashmate/.dashmate/{{ hpmn_backup_network_name }}/platform/gateway/ssl"
+hpmn_backup_tenderdash_volume_candidates:
+  - "/var/lib/docker/volumes/dashmate_{{ hpmn_backup_network_name }}_drive_tenderdash/_data"
+hpmn_backup_llmq_candidates:
+  - "/var/lib/docker/volumes/dashmate_{{ hpmn_backup_network_name }}_core_data/_data/.dashcore/testnet3/llmq"
+  - "/var/lib/docker/volumes/dashmate_{{ hpmn_backup_network_name }}_core_data/_data/.dashcore/{{ hpmn_backup_network_name }}/llmq"
+  - /dash/.dashcore/testnet3/llmq
+hpmn_backup_search_roots:
+  - "/home/dashmate/.dashmate/{{ hpmn_backup_network_name }}"
+  - /var/lib/docker/volumes

--- a/ansible/roles/hpmn_backup/tasks/main.yml
+++ b/ansible/roles/hpmn_backup/tasks/main.yml
@@ -3,6 +3,7 @@
   ansible.builtin.apt:
     pkg:
       - awscli
+      - rsync
     update_cache: true
     cache_valid_time: 3600
 

--- a/ansible/roles/hpmn_backup/tasks/main.yml
+++ b/ansible/roles/hpmn_backup/tasks/main.yml
@@ -1,0 +1,23 @@
+---
+- name: Install backup prerequisites
+  ansible.builtin.apt:
+    pkg:
+      - awscli
+    update_cache: true
+    cache_valid_time: 3600
+
+- name: Ensure backup staging dir exists
+  ansible.builtin.file:
+    path: "{{ hpmn_backup_staging_dir }}"
+    state: directory
+    owner: root
+    group: root
+    mode: "0750"
+
+- name: Install HP masternode backup script
+  ansible.builtin.template:
+    src: backup-hpmn.sh.j2
+    dest: "{{ hpmn_backup_script_path }}"
+    owner: root
+    group: root
+    mode: "0750"

--- a/ansible/roles/hpmn_backup/tasks/run.yml
+++ b/ansible/roles/hpmn_backup/tasks/run.yml
@@ -6,13 +6,19 @@
     hpmn_backup_trigger_label_resolved: "{{ hpmn_backup_trigger_label | default(lookup('env', 'HPMN_BACKUP_TRIGGER_LABEL'), true) | default('manual', true) }}"
     hpmn_backup_sse_mode_resolved: "{{ hpmn_backup_s3_sse_mode | default(lookup('env', 'HPMN_BACKUP_S3_SSE_MODE'), true) }}"
     hpmn_backup_kms_key_id_resolved: "{{ hpmn_backup_s3_kms_key_id | default(lookup('env', 'HPMN_BACKUP_S3_KMS_KEY_ID'), true) }}"
+    hpmn_backup_aws_region_resolved: "{{ hpmn_backup_aws_region | default(lookup('env', 'AWS_REGION'), true) | default(lookup('env', 'AWS_DEFAULT_REGION'), true) }}"
 
 - name: Validate controller environment for manual backup run
   ansible.builtin.assert:
     that:
       - hpmn_backup_bucket_resolved | length > 0
+      - hpmn_backup_aws_region_resolved | length > 0
+      - hpmn_backup_sse_mode_resolved in ['AES256', 'aws:kms']
+      - hpmn_backup_sse_mode_resolved == 'aws:kms' or hpmn_backup_kms_key_id_resolved | length == 0
+      - hpmn_backup_sse_mode_resolved != 'aws:kms' or hpmn_backup_kms_key_id_resolved | length > 0
     fail_msg: >-
-      Manual HPMN backup requires HPMN_BACKUP_S3_BUCKET on the control machine.
+      Manual HPMN backup requires HPMN_BACKUP_S3_BUCKET, AWS_REGION, and a valid SSE configuration.
+      Use AES256 with no KMS key, or aws:kms with HPMN_BACKUP_S3_KMS_KEY_ID.
 
 - name: Run HP masternode backup script
   ansible.builtin.command:
@@ -22,8 +28,8 @@
     AWS_ACCESS_KEY_ID: "{{ lookup('env', 'AWS_ACCESS_KEY_ID') }}"
     AWS_SECRET_ACCESS_KEY: "{{ lookup('env', 'AWS_SECRET_ACCESS_KEY') }}"
     AWS_SESSION_TOKEN: "{{ lookup('env', 'AWS_SESSION_TOKEN') }}"
-    AWS_REGION: "{{ lookup('env', 'AWS_REGION') }}"
-    AWS_DEFAULT_REGION: "{{ lookup('env', 'AWS_REGION') }}"
+    AWS_REGION: "{{ hpmn_backup_aws_region_resolved }}"
+    AWS_DEFAULT_REGION: "{{ hpmn_backup_aws_region_resolved }}"
     HPMN_BACKUP_BUCKET: "{{ hpmn_backup_bucket_resolved }}"
     HPMN_BACKUP_PREFIX: "{{ hpmn_backup_prefix_resolved }}"
     HPMN_BACKUP_LABEL: "{{ hpmn_backup_trigger_label_resolved }}"

--- a/ansible/roles/hpmn_backup/tasks/run.yml
+++ b/ansible/roles/hpmn_backup/tasks/run.yml
@@ -6,7 +6,12 @@
     hpmn_backup_trigger_label_resolved: "{{ hpmn_backup_trigger_label | default(lookup('env', 'HPMN_BACKUP_TRIGGER_LABEL'), true) | default('manual', true) }}"
     hpmn_backup_sse_mode_resolved: "{{ hpmn_backup_s3_sse_mode | default(lookup('env', 'HPMN_BACKUP_S3_SSE_MODE'), true) }}"
     hpmn_backup_kms_key_id_resolved: "{{ hpmn_backup_s3_kms_key_id | default(lookup('env', 'HPMN_BACKUP_S3_KMS_KEY_ID'), true) }}"
-    hpmn_backup_aws_region_resolved: "{{ hpmn_backup_aws_region | default(lookup('env', 'AWS_REGION'), true) | default(lookup('env', 'AWS_DEFAULT_REGION'), true) }}"
+    hpmn_backup_aws_region_resolved: >-
+      {{
+        hpmn_backup_aws_region
+        | default(lookup('env', 'AWS_REGION'), true)
+        | default(lookup('env', 'AWS_DEFAULT_REGION'), true)
+      }}
 
 - name: Validate controller environment for manual backup run
   ansible.builtin.assert:

--- a/ansible/roles/hpmn_backup/tasks/run.yml
+++ b/ansible/roles/hpmn_backup/tasks/run.yml
@@ -1,0 +1,38 @@
+---
+- name: Resolve backup upload configuration
+  ansible.builtin.set_fact:
+    hpmn_backup_bucket_resolved: "{{ hpmn_backup_s3_bucket | default(lookup('env', 'HPMN_BACKUP_S3_BUCKET'), true) }}"
+    hpmn_backup_prefix_resolved: "{{ lookup('env', 'HPMN_BACKUP_S3_PREFIX') | default(hpmn_backup_s3_prefix, true) }}"
+    hpmn_backup_trigger_label_resolved: "{{ hpmn_backup_trigger_label | default(lookup('env', 'HPMN_BACKUP_TRIGGER_LABEL'), true) | default('manual', true) }}"
+    hpmn_backup_sse_mode_resolved: "{{ hpmn_backup_s3_sse_mode | default(lookup('env', 'HPMN_BACKUP_S3_SSE_MODE'), true) }}"
+    hpmn_backup_kms_key_id_resolved: "{{ hpmn_backup_s3_kms_key_id | default(lookup('env', 'HPMN_BACKUP_S3_KMS_KEY_ID'), true) }}"
+
+- name: Validate controller environment for manual backup run
+  ansible.builtin.assert:
+    that:
+      - hpmn_backup_bucket_resolved | length > 0
+    fail_msg: >-
+      Manual HPMN backup requires HPMN_BACKUP_S3_BUCKET on the control machine.
+
+- name: Run HP masternode backup script
+  ansible.builtin.command:
+    argv:
+      - "{{ hpmn_backup_script_path }}"
+  environment:
+    AWS_ACCESS_KEY_ID: "{{ lookup('env', 'AWS_ACCESS_KEY_ID') }}"
+    AWS_SECRET_ACCESS_KEY: "{{ lookup('env', 'AWS_SECRET_ACCESS_KEY') }}"
+    AWS_SESSION_TOKEN: "{{ lookup('env', 'AWS_SESSION_TOKEN') }}"
+    AWS_REGION: "{{ lookup('env', 'AWS_REGION') }}"
+    AWS_DEFAULT_REGION: "{{ lookup('env', 'AWS_REGION') }}"
+    HPMN_BACKUP_BUCKET: "{{ hpmn_backup_bucket_resolved }}"
+    HPMN_BACKUP_PREFIX: "{{ hpmn_backup_prefix_resolved }}"
+    HPMN_BACKUP_LABEL: "{{ hpmn_backup_trigger_label_resolved }}"
+    HPMN_BACKUP_NETWORK: "{{ hpmn_backup_network_name }}"
+    HPMN_BACKUP_S3_SSE_MODE: "{{ hpmn_backup_sse_mode_resolved }}"
+    HPMN_BACKUP_S3_KMS_KEY_ID: "{{ hpmn_backup_kms_key_id_resolved }}"
+  register: hpmn_backup_run_result
+  changed_when: true
+
+- name: Show backup upload result
+  ansible.builtin.debug:
+    msg: "{{ hpmn_backup_run_result.stdout_lines | default([hpmn_backup_run_result.stdout]) }}"

--- a/ansible/roles/hpmn_backup/templates/backup-hpmn.sh.j2
+++ b/ansible/roles/hpmn_backup/templates/backup-hpmn.sh.j2
@@ -1,0 +1,135 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+require_env() {
+  local var_name="$1"
+  if [[ -z "${!var_name:-}" ]]; then
+    echo "Missing required environment variable: ${var_name}" >&2
+    exit 1
+  fi
+}
+
+sanitize_label() {
+  local raw_label="$1"
+  local sanitized
+
+  sanitized="$(printf '%s' "$raw_label" | tr -cs 'A-Za-z0-9._-' '-')"
+  sanitized="${sanitized#-}"
+  sanitized="${sanitized%-}"
+
+  if [[ -z "$sanitized" ]]; then
+    sanitized="manual"
+  fi
+
+  printf '%s' "$sanitized"
+}
+
+require_env "HPMN_BACKUP_BUCKET"
+
+timestamp="$(date -u +%Y%m%dT%H%M%SZ)"
+hostname_short="$(hostname -s)"
+network_name="${HPMN_BACKUP_NETWORK:-{{ hpmn_backup_network_name }}}"
+backup_prefix="${HPMN_BACKUP_PREFIX:-{{ hpmn_backup_s3_prefix }}}"
+backup_label="$(sanitize_label "${HPMN_BACKUP_LABEL:-manual}")"
+backup_id="${timestamp}_${backup_label}"
+archive_path="{{ hpmn_backup_staging_dir }}/${hostname_short}_${network_name}_${backup_id}.tar.gz"
+stage_dir="$(mktemp -d "{{ hpmn_backup_staging_dir }}/stage.${hostname_short}.${timestamp}.XXXXXX")"
+payload_dir="${stage_dir}/payload"
+manifest_path="${stage_dir}/manifest.txt"
+
+cleanup() {
+  rm -rf "$stage_dir"
+  rm -f "$archive_path"
+}
+
+trap cleanup EXIT
+
+mkdir -p "$payload_dir"
+
+declare -A seen_paths=()
+
+record_path() {
+  local status="$1"
+  local category="$2"
+  local path="$3"
+
+  printf '%s|%s|%s\n' "$status" "$category" "$path" >> "$manifest_path"
+}
+
+copy_path() {
+  local category="$1"
+  local path="$2"
+
+  if [[ -n "${seen_paths["$path"]:-}" ]]; then
+    return 0
+  fi
+
+  seen_paths["$path"]=1
+
+  if [[ -e "$path" ]]; then
+    cp -a --parents "$path" "$payload_dir"
+    record_path "included" "$category" "$path"
+  else
+    record_path "missing" "$category" "$path"
+  fi
+}
+
+record_path "metadata" "hostname" "$hostname_short"
+record_path "metadata" "network" "$network_name"
+record_path "metadata" "backup_id" "$backup_id"
+record_path "metadata" "generated_at_utc" "$timestamp"
+
+{% for path in hpmn_backup_static_paths %}
+copy_path "static" "{{ path }}"
+{% endfor %}
+
+{% for path in hpmn_backup_tenderdash_volume_candidates %}
+copy_path "tenderdash_volume_candidate" "{{ path }}"
+{% endfor %}
+
+{% for path in hpmn_backup_llmq_candidates %}
+copy_path "llmq_candidate" "{{ path }}"
+{% endfor %}
+
+while IFS= read -r -d '' discovered_path; do
+  copy_path "dynamic_discovery" "$discovered_path"
+done < <(
+  find \
+{% for root in hpmn_backup_search_roots %}
+    "{{ root }}" \
+{% endfor %}
+    -type f \
+    \( -name 'priv_validator_key.json' -o -name 'priv_validator_state.json' -o -name 'node_key.json' \) \
+    -print0 2>/dev/null
+)
+
+while IFS= read -r -d '' discovered_llmq; do
+  copy_path "dynamic_llmq" "$discovered_llmq"
+done < <(
+  find /var/lib/docker/volumes \
+    -type d \
+    \( -path '*/.dashcore/testnet3/llmq' -o -path "*/.dashcore/${network_name}/llmq" \) \
+    -print0 2>/dev/null
+)
+
+tar -C "$stage_dir" -czf "$archive_path" manifest.txt payload
+
+s3_object_key="${backup_prefix%/}/${network_name}/${hostname_short}/${backup_id}.tar.gz"
+s3_uri="s3://${HPMN_BACKUP_BUCKET}/${s3_object_key}"
+
+aws_args=(s3 cp "$archive_path" "$s3_uri" --no-progress)
+
+if [[ -n "${HPMN_BACKUP_S3_SSE_MODE:-}" ]]; then
+  aws_args+=(--sse "${HPMN_BACKUP_S3_SSE_MODE}")
+fi
+
+if [[ -n "${HPMN_BACKUP_S3_KMS_KEY_ID:-}" ]]; then
+  aws_args+=(--sse-kms-key-id "${HPMN_BACKUP_S3_KMS_KEY_ID}")
+fi
+
+aws "${aws_args[@]}"
+
+echo "BACKUP_HOST=${hostname_short}"
+echo "BACKUP_ID=${backup_id}"
+echo "BACKUP_S3_URI=${s3_uri}"

--- a/ansible/roles/hpmn_backup/templates/backup-hpmn.sh.j2
+++ b/ansible/roles/hpmn_backup/templates/backup-hpmn.sh.j2
@@ -31,6 +31,8 @@ timestamp="$(date -u +%Y%m%dT%H%M%SZ)"
 hostname_short="$(hostname -s)"
 network_name="${HPMN_BACKUP_NETWORK:-{{ hpmn_backup_network_name }}}"
 backup_prefix="${HPMN_BACKUP_PREFIX:-{{ hpmn_backup_s3_prefix }}}"
+sse_mode="${HPMN_BACKUP_S3_SSE_MODE:-{{ hpmn_backup_s3_sse_mode }}}"
+kms_key_id="${HPMN_BACKUP_S3_KMS_KEY_ID:-}"
 backup_label="$(sanitize_label "${HPMN_BACKUP_LABEL:-manual}")"
 backup_id="${timestamp}_${backup_label}"
 archive_path="{{ hpmn_backup_staging_dir }}/${hostname_short}_${network_name}_${backup_id}.tar.gz"
@@ -120,13 +122,29 @@ s3_uri="s3://${HPMN_BACKUP_BUCKET}/${s3_object_key}"
 
 aws_args=(s3 cp "$archive_path" "$s3_uri" --no-progress)
 
-if [[ -n "${HPMN_BACKUP_S3_SSE_MODE:-}" ]]; then
-  aws_args+=(--sse "${HPMN_BACKUP_S3_SSE_MODE}")
-fi
-
-if [[ -n "${HPMN_BACKUP_S3_KMS_KEY_ID:-}" ]]; then
-  aws_args+=(--sse-kms-key-id "${HPMN_BACKUP_S3_KMS_KEY_ID}")
-fi
+case "$sse_mode" in
+  "")
+    ;;
+  AES256)
+    aws_args+=(--sse AES256)
+    if [[ -n "$kms_key_id" ]]; then
+      echo "HPMN_BACKUP_S3_KMS_KEY_ID must be empty when SSE mode is AES256" >&2
+      exit 1
+    fi
+    ;;
+  aws:kms)
+    aws_args+=(--sse aws:kms)
+    if [[ -z "$kms_key_id" ]]; then
+      echo "HPMN_BACKUP_S3_KMS_KEY_ID is required when SSE mode is aws:kms" >&2
+      exit 1
+    fi
+    aws_args+=(--sse-kms-key-id "$kms_key_id")
+    ;;
+  *)
+    echo "Unsupported HPMN_BACKUP_S3_SSE_MODE: $sse_mode" >&2
+    exit 1
+    ;;
+esac
 
 aws "${aws_args[@]}"
 

--- a/ansible/roles/hpmn_backup/templates/backup-hpmn.sh.j2
+++ b/ansible/roles/hpmn_backup/templates/backup-hpmn.sh.j2
@@ -62,6 +62,7 @@ record_path() {
 copy_path() {
   local category="$1"
   local path="$2"
+  local rsync_rc
 
   if [[ -n "${seen_paths["$path"]:-}" ]]; then
     return 0
@@ -70,7 +71,14 @@ copy_path() {
   seen_paths["$path"]=1
 
   if [[ -e "$path" ]]; then
-    cp -a --parents "$path" "$payload_dir"
+    set +e
+    rsync -aR "$path" "$payload_dir"
+    rsync_rc=$?
+    set -e
+    if [[ $rsync_rc -ne 0 && $rsync_rc -ne 24 ]]; then
+      echo "Failed to capture path with rsync: $path" >&2
+      return "$rsync_rc"
+    fi
     record_path "included" "$category" "$path"
   else
     record_path "missing" "$category" "$path"
@@ -88,6 +96,10 @@ copy_path "static" "{{ path }}"
 
 {% for path in hpmn_backup_tenderdash_volume_candidates %}
 copy_path "tenderdash_volume_candidate" "{{ path }}"
+{% endfor %}
+
+{% for path in hpmn_backup_drive_abci_volume_candidates %}
+copy_path "drive_abci_volume_candidate" "{{ path }}"
 {% endfor %}
 
 {% for path in hpmn_backup_llmq_candidates %}

--- a/ansible/roles/hpmn_restore/defaults/main.yml
+++ b/ansible/roles/hpmn_restore/defaults/main.yml
@@ -1,0 +1,7 @@
+---
+hpmn_restore_script_path: /usr/local/bin/hpmn-restore
+hpmn_restore_staging_dir: /var/tmp/hpmn-restore
+hpmn_restore_network_name: "{{ dash_network_name | default('testnet') }}"
+hpmn_restore_dashmate_home: /home/dashmate
+hpmn_restore_start_services: false
+hpmn_restore_aws_region: ""

--- a/ansible/roles/hpmn_restore/defaults/main.yml
+++ b/ansible/roles/hpmn_restore/defaults/main.yml
@@ -5,3 +5,13 @@ hpmn_restore_network_name: "{{ dash_network_name | default('testnet') }}"
 hpmn_restore_dashmate_home: /home/dashmate
 hpmn_restore_start_services: false
 hpmn_restore_aws_region: ""
+hpmn_restore_volume_ownerships:
+  - path: "/var/lib/docker/volumes/dashmate_{{ hpmn_restore_network_name }}_core_data/_data"
+    owner: "1000"
+    group: "1000"
+  - path: "/var/lib/docker/volumes/dashmate_{{ hpmn_restore_network_name }}_drive_abci_data/_data"
+    owner: "1000"
+    group: "1000"
+  - path: "/var/lib/docker/volumes/dashmate_{{ hpmn_restore_network_name }}_drive_tenderdash/_data"
+    owner: "100"
+    group: "1000"

--- a/ansible/roles/hpmn_restore/tasks/main.yml
+++ b/ansible/roles/hpmn_restore/tasks/main.yml
@@ -1,0 +1,24 @@
+---
+- name: Install restore prerequisites
+  ansible.builtin.apt:
+    pkg:
+      - awscli
+      - rsync
+    update_cache: true
+    cache_valid_time: 3600
+
+- name: Ensure restore staging dir exists
+  ansible.builtin.file:
+    path: "{{ hpmn_restore_staging_dir }}"
+    state: directory
+    owner: root
+    group: root
+    mode: "0750"
+
+- name: Install HP masternode restore script
+  ansible.builtin.template:
+    src: restore-hpmn.sh.j2
+    dest: "{{ hpmn_restore_script_path }}"
+    owner: root
+    group: root
+    mode: "0750"

--- a/ansible/roles/hpmn_restore/tasks/run.yml
+++ b/ansible/roles/hpmn_restore/tasks/run.yml
@@ -3,7 +3,12 @@
   ansible.builtin.set_fact:
     hpmn_restore_s3_uri_resolved: "{{ hpmn_restore_s3_uri | default(lookup('env', 'HPMN_RESTORE_S3_URI'), true) }}"
     hpmn_restore_start_services_resolved: "{{ hpmn_restore_start_services | bool }}"
-    hpmn_restore_aws_region_resolved: "{{ hpmn_restore_aws_region | default(lookup('env', 'AWS_REGION'), true) | default(lookup('env', 'AWS_DEFAULT_REGION'), true) }}"
+    hpmn_restore_aws_region_resolved: >-
+      {{
+        hpmn_restore_aws_region
+        | default(lookup('env', 'AWS_REGION'), true)
+        | default(lookup('env', 'AWS_DEFAULT_REGION'), true)
+      }}
 
 - name: Validate restore inputs
   ansible.builtin.assert:

--- a/ansible/roles/hpmn_restore/tasks/run.yml
+++ b/ansible/roles/hpmn_restore/tasks/run.yml
@@ -1,0 +1,35 @@
+---
+- name: Resolve restore configuration
+  ansible.builtin.set_fact:
+    hpmn_restore_s3_uri_resolved: "{{ hpmn_restore_s3_uri | default(lookup('env', 'HPMN_RESTORE_S3_URI'), true) }}"
+    hpmn_restore_start_services_resolved: "{{ hpmn_restore_start_services | bool }}"
+    hpmn_restore_aws_region_resolved: "{{ hpmn_restore_aws_region | default(lookup('env', 'AWS_REGION'), true) | default(lookup('env', 'AWS_DEFAULT_REGION'), true) }}"
+
+- name: Validate restore inputs
+  ansible.builtin.assert:
+    that:
+      - hpmn_restore_s3_uri_resolved | length > 0
+      - hpmn_restore_aws_region_resolved | length > 0
+    fail_msg: >-
+      HPMN restore requires HPMN_RESTORE_S3_URI or hpmn_restore_s3_uri, plus AWS_REGION.
+
+- name: Run HP masternode restore script
+  ansible.builtin.command:
+    argv:
+      - "{{ hpmn_restore_script_path }}"
+  environment:
+    AWS_ACCESS_KEY_ID: "{{ lookup('env', 'AWS_ACCESS_KEY_ID') }}"
+    AWS_SECRET_ACCESS_KEY: "{{ lookup('env', 'AWS_SECRET_ACCESS_KEY') }}"
+    AWS_SESSION_TOKEN: "{{ lookup('env', 'AWS_SESSION_TOKEN') }}"
+    AWS_REGION: "{{ hpmn_restore_aws_region_resolved }}"
+    AWS_DEFAULT_REGION: "{{ hpmn_restore_aws_region_resolved }}"
+    HPMN_RESTORE_S3_URI: "{{ hpmn_restore_s3_uri_resolved }}"
+    HPMN_RESTORE_NETWORK: "{{ hpmn_restore_network_name }}"
+    HPMN_RESTORE_DASHMATE_HOME: "{{ hpmn_restore_dashmate_home }}"
+    HPMN_RESTORE_START_SERVICES: "{{ 'true' if hpmn_restore_start_services_resolved else 'false' }}"
+  register: hpmn_restore_run_result
+  changed_when: true
+
+- name: Show restore result
+  ansible.builtin.debug:
+    msg: "{{ hpmn_restore_run_result.stdout_lines | default([hpmn_restore_run_result.stdout]) }}"

--- a/ansible/roles/hpmn_restore/templates/restore-hpmn.sh.j2
+++ b/ansible/roles/hpmn_restore/templates/restore-hpmn.sh.j2
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+require_env() {
+  local var_name="$1"
+  if [[ -z "${!var_name:-}" ]]; then
+    echo "Missing required environment variable: ${var_name}" >&2
+    exit 1
+  fi
+}
+
+require_env "HPMN_RESTORE_S3_URI"
+
+restore_root="{{ hpmn_restore_staging_dir }}"
+network_name="${HPMN_RESTORE_NETWORK:-{{ hpmn_restore_network_name }}}"
+dashmate_home="${HPMN_RESTORE_DASHMATE_HOME:-{{ hpmn_restore_dashmate_home }}}"
+restore_archive="${restore_root}/restore.tar.gz"
+restore_dir="$(mktemp -d "${restore_root}/restore.XXXXXX")"
+payload_dir="${restore_dir}/payload"
+manifest_path="${restore_dir}/manifest.txt"
+start_services="${HPMN_RESTORE_START_SERVICES:-true}"
+
+cleanup() {
+  rm -rf "$restore_dir"
+  rm -f "$restore_archive"
+}
+
+trap cleanup EXIT
+
+mkdir -p "$restore_root"
+
+if command -v runuser >/dev/null 2>&1 && command -v dashmate >/dev/null 2>&1; then
+  runuser -u dashmate -- sh -lc "cd '$dashmate_home' && dashmate stop --verbose" || true
+fi
+
+docker ps --format '{% raw %}{{.Names}}{% endraw %}' | grep "^dashmate_${network_name}[-_]" | xargs -r docker stop >/dev/null 2>&1 || true
+
+aws s3 cp "$HPMN_RESTORE_S3_URI" "$restore_archive" --no-progress
+tar -xzf "$restore_archive" -C "$restore_dir"
+
+if [[ ! -f "$manifest_path" ]]; then
+  echo "Restore manifest missing from archive" >&2
+  exit 1
+fi
+
+while IFS='|' read -r status category path; do
+  [[ "$status" == "included" ]] || continue
+  source_path="${payload_dir}${path}"
+
+  if [[ -d "$source_path" ]]; then
+    mkdir -p "$path"
+    rsync -a --delete "${source_path}/" "${path}/"
+  elif [[ -f "$source_path" ]]; then
+    mkdir -p "$(dirname "$path")"
+    rsync -a "$source_path" "$path"
+  fi
+done < "$manifest_path"
+
+if [[ "$start_services" == "true" ]] && command -v runuser >/dev/null 2>&1 && command -v dashmate >/dev/null 2>&1; then
+  runuser -u dashmate -- sh -lc "cd '$dashmate_home' && dashmate start --force --verbose"
+fi
+
+echo "RESTORE_S3_URI=${HPMN_RESTORE_S3_URI}"
+echo "RESTORE_HOST=$(hostname -s)"
+echo "RESTORE_START_SERVICES=${start_services}"

--- a/ansible/roles/hpmn_restore/templates/restore-hpmn.sh.j2
+++ b/ansible/roles/hpmn_restore/templates/restore-hpmn.sh.j2
@@ -57,6 +57,12 @@ while IFS='|' read -r status category path; do
   fi
 done < "$manifest_path"
 
+{% for volume in hpmn_restore_volume_ownerships %}
+if [[ -e "{{ volume.path }}" ]]; then
+  chown -R {{ volume.owner }}:{{ volume.group }} "{{ volume.path }}"
+fi
+{% endfor %}
+
 if [[ "$start_services" == "true" ]] && command -v runuser >/dev/null 2>&1 && command -v dashmate >/dev/null 2>&1; then
   runuser -u dashmate -- sh -lc "cd '$dashmate_home' && dashmate start --force --verbose"
 fi

--- a/docs/hpmn-backup.md
+++ b/docs/hpmn-backup.md
@@ -20,6 +20,8 @@ The current backup script captures the highest-value runtime state it can find w
 - `/home/dashmate/.dashmate/<network>/platform/gateway/ssl`
 - Tenderdash named volume data under:
   - `/var/lib/docker/volumes/dashmate_<network>_drive_tenderdash/_data`
+- Drive ABCI named volume data under:
+  - `/var/lib/docker/volumes/dashmate_<network>_drive_abci_data/_data`
 - likely Dash Core quorum state under Docker volume paths such as:
   - `/var/lib/docker/volumes/dashmate_<network>_core_data/_data/.dashcore/testnet3/llmq`
 

--- a/docs/hpmn-backup.md
+++ b/docs/hpmn-backup.md
@@ -146,6 +146,8 @@ If it is `aws:kms`, set `HPMN_BACKUP_S3_KMS_KEY_ID`.
 
 Restore is intentionally single-host only. Use a replacement or disposable HP masternode, not the whole group.
 
+For the full tested step-by-step recovery procedure, including public IP cutover, replacement host provisioning, restore, finalize, verification, and troubleshooting, use [`docs/hpmn-recovery.md`](/home/vivek/code/dash-network-deploy/docs/hpmn-recovery.md).
+
 One-time restore tooling install:
 
 ```bash

--- a/docs/hpmn-backup.md
+++ b/docs/hpmn-backup.md
@@ -1,0 +1,127 @@
+# HP Masternode Backup
+
+This workflow is scoped to `hp_masternodes` only. It is intended to be manual and trigger-only.
+
+## Design
+
+- The backup script is installed on HP masternodes one time with a dedicated Ansible role.
+- A separate playbook runs the backup on demand.
+- The backup archive is uploaded directly from each HP masternode to S3.
+- No reboot, service stop, or platform reset is part of this flow.
+- `deploy.yml` is intentionally untouched. Use the dedicated playbooks instead of `./bin/deploy -p`.
+
+## What Gets Backed Up
+
+The current backup script captures the highest-value runtime state it can find without stopping services:
+
+- `/home/dashmate/.dashmate/config.json`
+- `/home/dashmate/.dashmate/<network>/platform/drive/tenderdash`
+- `/home/dashmate/.dashmate/<network>/platform/gateway/ssl`
+- Tenderdash named volume data under:
+  - `/var/lib/docker/volumes/dashmate_<network>_drive_tenderdash/_data`
+- likely Dash Core quorum state under Docker volume paths such as:
+  - `/var/lib/docker/volumes/dashmate_<network>_core_data/_data/.dashcore/testnet3/llmq`
+
+The script also performs runtime discovery for:
+
+- `priv_validator_key.json`
+- `priv_validator_state.json`
+- `node_key.json`
+
+Each archive contains a `manifest.txt` that records included and missing paths.
+
+## S3 Layout
+
+Objects are stamped by network, host, timestamp, and trigger label:
+
+```text
+s3://<bucket>/<prefix>/<network>/<hostname>/<timestamp>_<label>.tar.gz
+```
+
+Example:
+
+```text
+s3://dash-hpmn-backups/hpmn-backups/testnet/hp-masternode-7/20260414T183500Z_pre-upgrade-check.tar.gz
+```
+
+## One-Time Install
+
+Install the backup prerequisites and script on all HP masternodes:
+
+```bash
+ansible-playbook \
+  -i networks/testnet.inventory \
+  ansible/hpmn_backup_install.yml \
+  -e @networks/testnet.yml \
+  -e dash_network_name=testnet
+```
+
+Install on a single node first:
+
+```bash
+ansible-playbook \
+  -i networks/testnet.inventory \
+  ansible/hpmn_backup_install.yml \
+  -e @networks/testnet.yml \
+  -e dash_network_name=testnet \
+  --limit hp-masternode-1
+```
+
+## Manual Trigger
+
+Run a backup on demand. Credentials remain on the control machine and are only passed for that run:
+
+```bash
+AWS_ACCESS_KEY_ID=... \
+AWS_SECRET_ACCESS_KEY=... \
+AWS_REGION=us-west-2 \
+HPMN_BACKUP_S3_BUCKET=your-bucket \
+HPMN_BACKUP_S3_PREFIX=hpmn-backups \
+ansible-playbook \
+  -i networks/testnet.inventory \
+  ansible/hpmn_backup_run.yml \
+  -e @networks/testnet.yml \
+  -e dash_network_name=testnet \
+  -e hpmn_backup_trigger_label=manual-test
+```
+
+Target a single HP masternode first during validation:
+
+```bash
+AWS_ACCESS_KEY_ID=... \
+AWS_SECRET_ACCESS_KEY=... \
+AWS_REGION=us-west-2 \
+HPMN_BACKUP_S3_BUCKET=your-bucket \
+ansible-playbook \
+  -i networks/testnet.inventory \
+  ansible/hpmn_backup_run.yml \
+  -e @networks/testnet.yml \
+  -e dash_network_name=testnet \
+  -e hpmn_backup_trigger_label=single-node-test \
+  --limit hp-masternode-1
+```
+
+## GitHub Actions Workflow
+
+Use `.github/workflows/hpmn-backup.yml` for a manual `workflow_dispatch` run.
+
+Suggested secrets:
+
+- `DEPLOY_SERVER_KEY`
+- `EVO_APP_DEPLOY_KEY`
+- `AWS_ACCESS_KEY_ID`
+- `AWS_SECRET_ACCESS_KEY`
+- `AWS_REGION`
+- `HPMN_BACKUP_S3_KMS_KEY_ID` if using SSE-KMS
+
+Suggested repository variables:
+
+- `HPMN_BACKUP_S3_BUCKET`
+- `HPMN_BACKUP_S3_PREFIX`
+- `HPMN_BACKUP_S3_SSE_MODE`
+
+## Restore Notes
+
+- Restore should be tested on a single replacement node first.
+- Do not bring up a second live validator with the same identity while the original HP masternode is still active.
+- The archive manifest should be reviewed before restore so we know exactly which runtime files were captured from that host.

--- a/docs/hpmn-backup.md
+++ b/docs/hpmn-backup.md
@@ -25,6 +25,9 @@ The current backup script captures the highest-value runtime state it can find w
 - likely Dash Core quorum state under Docker volume paths such as:
   - `/var/lib/docker/volumes/dashmate_<network>_core_data/_data/.dashcore/testnet3/llmq`
 
+It does not back up the full Dash Core chainstate.
+On restore, the node may need to resync Core from the network while preserving quorum and Platform runtime state.
+
 The script also performs runtime discovery for:
 
 - `priv_validator_key.json`
@@ -199,3 +202,7 @@ There is also a dedicated `workflow_dispatch` GitHub Actions workflow at `.githu
 - Do not bring up a second live validator with the same identity while the original HP masternode is still active.
 - The archive manifest should be reviewed before restore so we know exactly which runtime files were captured from that host.
 - On a replacement host, run the finalize step after restore so `config.json` and rendered dashmate files use the replacement node's actual inventory IPs.
+- The restore script now reapplies expected ownership to the restored Docker volumes before startup:
+  - Core: `1000:1000`
+  - Drive ABCI: `1000:1000`
+  - Tenderdash: `100:1000`

--- a/docs/hpmn-backup.md
+++ b/docs/hpmn-backup.md
@@ -6,6 +6,7 @@ This workflow is scoped to `hp_masternodes` only. It is intended to be manual an
 
 - The backup script is installed on HP masternodes one time with a dedicated Ansible role.
 - A separate playbook runs the backup on demand.
+- Backup execution is batched by default to avoid hitting all HPMNs at once.
 - The backup archive is uploaded directly from each HP masternode to S3.
 - No reboot, service stop, or platform reset is part of this flow.
 - `deploy.yml` is intentionally untouched. Use the dedicated playbooks instead of `./bin/deploy -p`.
@@ -101,6 +102,24 @@ ansible-playbook \
   --limit hp-masternode-1
 ```
 
+Run a fleet operation in controlled batches:
+
+```bash
+AWS_ACCESS_KEY_ID=... \
+AWS_SECRET_ACCESS_KEY=... \
+AWS_SESSION_TOKEN=... \
+AWS_REGION=us-west-2 \
+HPMN_BACKUP_S3_BUCKET=dash-testnet-hpmns-backups \
+ansible-playbook \
+  -i networks/testnet.inventory \
+  ansible/hpmn_backup_run.yml \
+  -e @networks/testnet.yml \
+  -e dash_network_name=testnet \
+  -e hpmn_backup_trigger_label=batch-run \
+  -e hpmn_backup_serial=5 \
+  --limit hp_masternodes
+```
+
 ## GitHub Actions Workflow
 
 Use `.github/workflows/hpmn-backup.yml` for a manual `workflow_dispatch` run.
@@ -120,8 +139,59 @@ Suggested repository variables:
 - `HPMN_BACKUP_S3_PREFIX`
 - `HPMN_BACKUP_S3_SSE_MODE`
 
+If `HPMN_BACKUP_S3_SSE_MODE` is `AES256`, leave the KMS key secret empty.
+If it is `aws:kms`, set `HPMN_BACKUP_S3_KMS_KEY_ID`.
+
+## Restore
+
+Restore is intentionally single-host only. Use a replacement or disposable HP masternode, not the whole group.
+
+One-time restore tooling install:
+
+```bash
+ansible-playbook \
+  -i networks/testnet.inventory \
+  ansible/hpmn_restore_install.yml \
+  -e @networks/testnet.yml \
+  -e dash_network_name=testnet \
+  --limit hp-masternode-1
+```
+
+Run restore from a specific backup archive:
+
+```bash
+AWS_ACCESS_KEY_ID=... \
+AWS_SECRET_ACCESS_KEY=... \
+AWS_SESSION_TOKEN=... \
+AWS_REGION=us-west-2 \
+ansible-playbook \
+  -i networks/testnet.inventory \
+  ansible/hpmn_restore_run.yml \
+  -e @networks/testnet.yml \
+  -e dash_network_name=testnet \
+  -e hpmn_restore_s3_uri=s3://dash-testnet-hpmns-backups/hpmn-backups/testnet/hp-masternode-1/example.tar.gz \
+  -e hpmn_restore_start_services=false \
+  --limit hp-masternode-1
+```
+
+Finalize the restored host so dashmate config is regenerated for the replacement node's inventory values and services start cleanly:
+
+```bash
+AWS_REGION=us-west-2 \
+ansible-playbook \
+  -i networks/testnet.inventory \
+  ansible/hpmn_restore_finalize.yml \
+  -e @networks/testnet.yml \
+  -e dash_network_name=testnet \
+  -e dash_network=testnet \
+  --limit hp-masternode-1
+```
+
+There is also a dedicated `workflow_dispatch` GitHub Actions workflow at `.github/workflows/hpmn-restore.yml`. By default it restores without auto-starting services, then runs the finalize playbook.
+
 ## Restore Notes
 
 - Restore should be tested on a single replacement node first.
 - Do not bring up a second live validator with the same identity while the original HP masternode is still active.
 - The archive manifest should be reviewed before restore so we know exactly which runtime files were captured from that host.
+- On a replacement host, run the finalize step after restore so `config.json` and rendered dashmate files use the replacement node's actual inventory IPs.

--- a/docs/hpmn-recovery.md
+++ b/docs/hpmn-recovery.md
@@ -37,6 +37,7 @@ The current HPMN backup captures:
 - `/home/dashmate/.dashmate/<network>/platform/drive/tenderdash`
 - `/home/dashmate/.dashmate/<network>/platform/gateway/ssl`
 - `/var/lib/docker/volumes/dashmate_<network>_drive_tenderdash/_data`
+- `/var/lib/docker/volumes/dashmate_<network>_drive_abci_data/_data`
 - `/var/lib/docker/volumes/dashmate_<network>_core_data/_data/.dashcore/testnet3/llmq`
 - runtime discovery hits for:
   - `priv_validator_key.json`
@@ -47,17 +48,21 @@ Each archive also contains `manifest.txt`.
 
 ## Recovery Outcome From Rehearsal
 
-The recovery rehearsal on `hp-masternode-1` proved:
+The first recovery rehearsal on `hp-masternode-1` proved:
 
 - the archive can be restored onto a replacement host
 - the old public IP can be moved to the replacement host
 - all dashmate services can be brought up on the replacement host
 - recovery requires a finalize step after restore so host-specific config is rerendered with the replacement node's real private IP
 
-The rehearsal also showed:
+The first rehearsal also exposed an incomplete backup scope:
 
-- the node may still need time to complete core sync before the network fully accepts it
-- `WAITING_FOR_PROTX` during sync does not immediately mean restore failed
+- the restored node eventually hit `votes extensions mismatch`
+- the node became `POSE_BANNED`
+- the missing runtime state was the Drive ABCI Docker volume at `/var/lib/docker/volumes/dashmate_<network>_drive_abci_data/_data`
+
+The backup role has since been updated to include that Drive ABCI volume.
+The next restore rehearsal must use a fresh archive created after that fix.
 
 ## Inputs You Need
 
@@ -105,7 +110,7 @@ The rehearsal also showed:
 Example:
 
 ```text
-s3://dash-testnet-hpmns-backups/hpmn-backups/testnet/hp-masternode-1/20260414T121720Z_second-test.tar.gz
+s3://dash-testnet-hpmns-backups/hpmn-backups/testnet/hp-masternode-1/20260414T154955Z_abci-fix-test.tar.gz
 ```
 
 Optional verification:
@@ -113,7 +118,7 @@ Optional verification:
 ```bash
 aws s3api head-object \
   --bucket dash-testnet-hpmns-backups \
-  --key hpmn-backups/testnet/hp-masternode-1/20260414T121720Z_second-test.tar.gz \
+  --key hpmn-backups/testnet/hp-masternode-1/20260414T154955Z_abci-fix-test.tar.gz \
   --region us-west-2
 ```
 
@@ -251,7 +256,7 @@ ansible-playbook \
   ansible/hpmn_restore_run.yml \
   -e @networks/testnet.yml \
   -e dash_network_name=testnet \
-  -e hpmn_restore_s3_uri=s3://dash-testnet-hpmns-backups/hpmn-backups/testnet/hp-masternode-1/20260414T121720Z_second-test.tar.gz \
+  -e hpmn_restore_s3_uri=s3://dash-testnet-hpmns-backups/hpmn-backups/testnet/hp-masternode-1/20260414T154955Z_abci-fix-test.tar.gz \
   -e hpmn_restore_start_services=false \
   --limit hp-masternode-1 \
   --private-key /home/vivek/.ssh/evo-app-deploy.rsa

--- a/docs/hpmn-recovery.md
+++ b/docs/hpmn-recovery.md
@@ -44,6 +44,9 @@ The current HPMN backup captures:
   - `priv_validator_state.json`
   - `node_key.json`
 
+It does not capture the full Dash Core chainstate.
+Expect Core to resync from the network during recovery.
+
 Each archive also contains `manifest.txt`.
 
 ## Recovery Outcome From Rehearsal
@@ -63,6 +66,7 @@ The first rehearsal also exposed an incomplete backup scope:
 
 The backup role has since been updated to include that Drive ABCI volume.
 The next restore rehearsal must use a fresh archive created after that fix.
+The restore role also reapplies expected ownership to restored Docker volumes before startup so Core, Drive ABCI, and Tenderdash can write to their data paths.
 
 ## Inputs You Need
 

--- a/docs/hpmn-recovery.md
+++ b/docs/hpmn-recovery.md
@@ -1,0 +1,419 @@
+# HP Masternode Recovery Runbook
+
+This document describes the tested recovery procedure for a single `testnet` HP masternode using the HPMN backup archive stored in S3.
+
+It is written to be followed by both humans and AI agents.
+
+## Scope
+
+This runbook is for:
+
+- a single replacement or disposable HP masternode
+- `testnet`
+- restore from the HPMN backup archive created by the backup role in this repo
+
+This runbook is not for:
+
+- restoring all HPMNs at once
+- regular masternodes
+- full fleet automation without human review
+
+## Important Rules
+
+- Never bring up a second live validator with the same identity while the original node is still active.
+- Stop or isolate the original HPMN before moving identity and public IP to a replacement host.
+- On a replacement host, do not rely on the archived `config.json` alone for final startup.
+- The correct recovery flow is:
+  1. provision replacement host
+  2. restore archive
+  3. finalize the host so dashmate config is regenerated for the replacement host's actual inventory values
+  4. verify sync and network acceptance
+
+## What the Backup Contains
+
+The current HPMN backup captures:
+
+- `/home/dashmate/.dashmate/config.json`
+- `/home/dashmate/.dashmate/<network>/platform/drive/tenderdash`
+- `/home/dashmate/.dashmate/<network>/platform/gateway/ssl`
+- `/var/lib/docker/volumes/dashmate_<network>_drive_tenderdash/_data`
+- `/var/lib/docker/volumes/dashmate_<network>_core_data/_data/.dashcore/testnet3/llmq`
+- runtime discovery hits for:
+  - `priv_validator_key.json`
+  - `priv_validator_state.json`
+  - `node_key.json`
+
+Each archive also contains `manifest.txt`.
+
+## Recovery Outcome From Rehearsal
+
+The recovery rehearsal on `hp-masternode-1` proved:
+
+- the archive can be restored onto a replacement host
+- the old public IP can be moved to the replacement host
+- all dashmate services can be brought up on the replacement host
+- recovery requires a finalize step after restore so host-specific config is rerendered with the replacement node's real private IP
+
+The rehearsal also showed:
+
+- the node may still need time to complete core sync before the network fully accepts it
+- `WAITING_FOR_PROTX` during sync does not immediately mean restore failed
+
+## Inputs You Need
+
+- the target host name, for example `hp-masternode-1`
+- the backup archive S3 URI
+- AWS credentials with access to the backup bucket
+- `AWS_REGION`
+- SSH access to the target host
+- the replacement instance details:
+  - instance id
+  - public IP / reassigned EIP or BYOIP allocation
+  - private IP
+  - subnet
+  - security groups
+  - IAM instance profile
+  - root volume sizing
+- a temporary inventory override or updated inventory entry that reflects the replacement host's actual `private_ip`
+
+## Repo Files Used During Recovery
+
+- [`ansible/hpmn_restore_install.yml`](/home/vivek/code/dash-network-deploy/ansible/hpmn_restore_install.yml)
+- [`ansible/hpmn_restore_run.yml`](/home/vivek/code/dash-network-deploy/ansible/hpmn_restore_run.yml)
+- [`ansible/hpmn_restore_finalize.yml`](/home/vivek/code/dash-network-deploy/ansible/hpmn_restore_finalize.yml)
+- [`ansible/deploy.yml`](/home/vivek/code/dash-network-deploy/ansible/deploy.yml)
+- [`docs/hpmn-backup.md`](/home/vivek/code/dash-network-deploy/docs/hpmn-backup.md)
+
+## High-Level Recovery Flow
+
+1. Identify the source node and the backup archive to restore.
+2. Launch a replacement EC2 instance with matching baseline infrastructure settings.
+3. Stop the old instance.
+4. Move the original public IP to the replacement instance.
+5. Prepare an inventory entry that points to the replacement instance and uses its real `private_ip`.
+6. Provision the replacement host enough to install Docker, dashmate, and base config.
+7. Install restore tooling.
+8. Restore the archive without starting services from the archived config.
+9. Finalize the host so dashmate regenerates host-specific config using the replacement host's inventory values.
+10. Verify service health and wait for core/platform sync.
+11. Confirm network acceptance before doing any broader rollout.
+
+## Step-by-Step Procedure
+
+### 1. Choose the Backup Archive
+
+Example:
+
+```text
+s3://dash-testnet-hpmns-backups/hpmn-backups/testnet/hp-masternode-1/20260414T121720Z_second-test.tar.gz
+```
+
+Optional verification:
+
+```bash
+aws s3api head-object \
+  --bucket dash-testnet-hpmns-backups \
+  --key hpmn-backups/testnet/hp-masternode-1/20260414T121720Z_second-test.tar.gz \
+  --region us-west-2
+```
+
+### 2. Launch a Replacement Instance
+
+Launch a replacement EC2 instance that matches the original node closely enough for service parity:
+
+- same region
+- same subnet
+- same security groups
+- same IAM instance profile
+- same key pair
+- same root disk size/class
+- same instance type unless there is a reason to change it
+
+If this is a true failover rehearsal, keep the replacement host separate until the original is stopped and the public IP is moved.
+
+### 3. Stop the Original HPMN
+
+Do not restore the same HPMN identity onto a second live node while the original node is still active.
+
+Example:
+
+```bash
+aws ec2 stop-instances \
+  --instance-ids <old-instance-id> \
+  --region us-west-2
+
+aws ec2 wait instance-stopped \
+  --instance-ids <old-instance-id> \
+  --region us-west-2
+```
+
+### 4. Move the Public IP
+
+Move the original public IP to the replacement instance.
+
+Example:
+
+```bash
+aws ec2 associate-address \
+  --allocation-id <allocation-id> \
+  --instance-id <replacement-instance-id> \
+  --allow-reassociation \
+  --region us-west-2
+```
+
+Verify:
+
+```bash
+aws ec2 describe-addresses \
+  --allocation-ids <allocation-id> \
+  --region us-west-2
+```
+
+### 5. Prepare Inventory for the Replacement Host
+
+The replacement host must use its actual private IP in inventory.
+
+This matters because dashmate renders listeners and metrics bindings using `private_ip`.
+
+If the original inventory entry still has the old private IP, create a temporary one-host override.
+
+Example host line:
+
+```text
+hp-masternode-1 ansible_user='ubuntu' ansible_host=68.67.122.1 public_ip=68.67.122.1 private_ip=10.0.24.125
+```
+
+### 6. Bootstrap the Replacement Host
+
+Run the one-host deploy flow against the replacement instance.
+
+Required variables:
+
+- `dash_network_name=testnet`
+- `dash_network=testnet`
+
+If you only need the replacement host to reach a baseline before restore, a limited one-host run is sufficient.
+
+Example:
+
+```bash
+AWS_REGION=us-west-2 \
+AWS_DEFAULT_REGION=us-west-2 \
+ANSIBLE_LOCAL_TEMP=/tmp/ansible-local \
+ANSIBLE_HOST_KEY_CHECKING=false \
+ansible-playbook \
+  -i /tmp/testnet-hp-masternode-1-cutover.inventory \
+  ansible/deploy.yml \
+  -e @networks/testnet.yml \
+  -e dash_network_name=testnet \
+  -e dash_network=testnet \
+  --limit hp-masternode-1 \
+  --private-key /home/vivek/.ssh/evo-app-deploy.rsa
+```
+
+Notes:
+
+- the recovery rehearsal exposed fresh-host issues that are now fixed in repo:
+  - `acl` is installed during bootstrap
+  - the `dashmate` user is added to the `docker` group correctly
+- if you only need the host bootstrapped before restore, later non-critical roles are less important than getting Docker and dashmate in place
+
+### 7. Install Restore Tooling
+
+```bash
+ANSIBLE_LOCAL_TEMP=/tmp/ansible-local \
+ANSIBLE_HOST_KEY_CHECKING=false \
+ansible-playbook \
+  -i /tmp/testnet-hp-masternode-1-cutover.inventory \
+  ansible/hpmn_restore_install.yml \
+  -e @networks/testnet.yml \
+  -e dash_network_name=testnet \
+  --limit hp-masternode-1 \
+  --private-key /home/vivek/.ssh/evo-app-deploy.rsa
+```
+
+### 8. Restore the Archive
+
+Important:
+
+- pass AWS credentials and region from the control machine
+- restore without auto-starting services
+
+```bash
+eval "$(aws configure export-credentials --format env)"
+
+AWS_REGION=us-west-2 \
+AWS_DEFAULT_REGION=us-west-2 \
+ANSIBLE_LOCAL_TEMP=/tmp/ansible-local \
+ANSIBLE_HOST_KEY_CHECKING=false \
+ansible-playbook \
+  -i /tmp/testnet-hp-masternode-1-cutover.inventory \
+  ansible/hpmn_restore_run.yml \
+  -e @networks/testnet.yml \
+  -e dash_network_name=testnet \
+  -e hpmn_restore_s3_uri=s3://dash-testnet-hpmns-backups/hpmn-backups/testnet/hp-masternode-1/20260414T121720Z_second-test.tar.gz \
+  -e hpmn_restore_start_services=false \
+  --limit hp-masternode-1 \
+  --private-key /home/vivek/.ssh/evo-app-deploy.rsa
+```
+
+Why `hpmn_restore_start_services=false`:
+
+- the archived `config.json` may still contain the old host's `private_ip`
+- starting services before rerendering config can fail on listeners bound to the old private IP
+
+### 9. Finalize the Restored Host
+
+This step is required on a replacement host.
+
+It regenerates dashmate config using the replacement host's inventory values and starts/restarts services cleanly.
+
+```bash
+AWS_REGION=us-west-2 \
+AWS_DEFAULT_REGION=us-west-2 \
+ANSIBLE_LOCAL_TEMP=/tmp/ansible-local \
+ANSIBLE_HOST_KEY_CHECKING=false \
+ansible-playbook \
+  -i /tmp/testnet-hp-masternode-1-cutover.inventory \
+  ansible/hpmn_restore_finalize.yml \
+  -e @networks/testnet.yml \
+  -e dash_network_name=testnet \
+  -e dash_network=testnet \
+  --limit hp-masternode-1 \
+  --private-key /home/vivek/.ssh/evo-app-deploy.rsa
+```
+
+### 10. Verify Services
+
+Check dashmate services:
+
+```bash
+sudo -u dashmate dashmate status services --format=json
+```
+
+Check running containers:
+
+```bash
+docker ps
+```
+
+### 11. Verify the Old Private IP Is Gone From Config
+
+Example:
+
+```bash
+sudo grep -R "10.0.28.10" -n /home/dashmate/.dashmate
+```
+
+This should return no matches after finalize for a replacement host with a different private IP.
+
+### 12. Wait for Core and Platform Sync
+
+Do not judge recovery too early.
+
+Useful checks:
+
+```bash
+dash-cli getblockchaininfo
+dash-cli mnsync status
+dash-cli masternode status
+docker logs --tail=20 dashmate_testnet-drive_abci-1
+```
+
+Healthy progression looks like:
+
+- `getblockcount` continues increasing
+- `initialblockdownload` eventually becomes `false`
+- `mnsync` reaches full sync
+- `drive_abci` stops waiting for core to sync
+- chainlock errors stop appearing
+- `masternode status` moves away from `WAITING_FOR_PROTX`
+
+### 13. Confirm Network Acceptance
+
+Only after sync completes should you conclude the recovery fully passed.
+
+Until then, the correct state is:
+
+- service recovery passed
+- network acceptance pending sync completion
+
+## Common Failure Modes
+
+### `Invalid endpoint: https://s3..amazonaws.com`
+
+Cause:
+
+- `AWS_REGION` was not present in the environment passed to the restore or backup run
+
+Fix:
+
+- export `AWS_REGION` and `AWS_DEFAULT_REGION`
+- rerun the playbook
+
+### `403` when reading the backup object from S3
+
+Cause:
+
+- the target host did not receive usable AWS credentials through the restore run
+
+Fix:
+
+```bash
+eval "$(aws configure export-credentials --format env)"
+```
+
+Then rerun the restore playbook with those exported credentials in the controller environment.
+
+### Dashmate refuses to stop due to DKG participation
+
+Cause:
+
+- dashmate protects against unsafe shutdown during DKG activity
+
+Fix:
+
+- in the tested restore script this is tolerated and the flow continues to stop relevant Docker containers directly
+- this warning is not by itself a restore failure
+
+### Service startup fails trying to bind the old private IP
+
+Cause:
+
+- archived `config.json` still contains the old host's private IP
+
+Fix:
+
+- do not start services directly from restore on a replacement host
+- run `ansible/hpmn_restore_finalize.yml`
+
+### `WAITING_FOR_PROTX` immediately after restore
+
+Cause:
+
+- often core is still syncing
+
+Fix:
+
+- wait for `getblockchaininfo` and `mnsync status` to catch up before treating this as a real failure
+
+### `drive_abci` logs show `waiting for core to sync`
+
+Cause:
+
+- core is not fully synced or chainlocks are not yet available locally
+
+Fix:
+
+- continue waiting while block height advances
+- reassess only after sync stabilizes
+
+## Recommended Operator Decision Point
+
+Before any fleet rollout:
+
+- complete one-node restore rehearsal
+- complete one-node sync validation
+- confirm the node is accepted by the network after sync
+
+Only after that should backup or recovery be expanded in batches across the remaining HPMNs.


### PR DESCRIPTION
## Issue being fixed or feature implemented

Implements the first HP masternode backup workflow for `testnet` as follow-up work for infra issue `#25`.

This change is scoped to `hp_masternodes` only and is intended to provide a repeatable backup path for the runtime state that matters most for HPMN recovery, without relying on full-instance snapshots or
modifying the existing `deploy.yml` flow.

Related context:
- HP masternode backup strategy for testnet `#25`
- EBS snapshot audit / cleanup `#24`

## What was done?

Added a dedicated HPMN backup implementation under Ansible, plus documentation and a GitHub Actions workflow scaffold.

Changes include:
- added `ansible/roles/hpmn_backup`
- added `ansible/hpmn_backup_install.yml` for one-time backup tooling installation on HPMNs
- added `ansible/hpmn_backup_run.yml` for on-demand backup execution
- added `.github/workflows/hpmn-backup.yml` for `workflow_dispatch`-based triggering
- added `docs/hpmn-backup.md`

The backup flow is isolated from normal provisioning and does not require using `./bin/deploy -p`.

The backup currently collects the following runtime state on each HP masternode:
- `/home/dashmate/.dashmate/config.json`
- `/home/dashmate/.dashmate/<network>/platform/drive/tenderdash`
- `/home/dashmate/.dashmate/<network>/platform/gateway/ssl`
- `/var/lib/docker/volumes/dashmate_<network>_drive_tenderdash/_data`
- `/var/lib/docker/volumes/dashmate_<network>_core_data/_data/.dashcore/testnet3/llmq`

The backup archive is created locally on the HPMN and uploaded directly to S3 with stamped object paths using:
- network
- hostname
- UTC timestamp
- trigger label

This implementation is designed to be non-disruptive:
- no reboot
- no service stop
- no `dashmate reset`
- no container restart

## How Has This Been Tested?

Functional testing was performed against live `testnet` infrastructure on `hp-masternode-1`.

Read-only verification on `hp-masternode-1` confirmed the presence of:
- Dashmate config
- Tenderdash host config
- gateway SSL material
- Core `llmq`
- Tenderdash named Docker volume

It also confirmed that `priv_validator_key.json` / `priv_validator_state.json` were not present on the host or visible in the running container during inspection.

Live validation performed:
1. Ran `ansible/hpmn_backup_install.yml` against `hp-masternode-1`
2. Triggered one backup run and verified upload to S3
3. Inspected the uploaded archive manifest
4. Expanded backup scope to include the Tenderdash named volume
5. Reinstalled updated backup script on `hp-masternode-1`
6. Deleted the first test object from S3
7. Reran the backup and revalidated the resulting archive

Validated S3 bucket:
- `s3://dash-testnet-hpmns-backups`

Validated uploaded test object:
- `s3://dash-testnet-hpmns-backups/hpmn-backups/testnet/hp-masternode-1/20260414T121720Z_second-test.tar.gz`

Observed result:
- upload completed successfully
- resulting archive size was ~1.62 GB
- S3 object stored with `AES256` server-side encryption
- archive manifest confirmed inclusion of:
  - config.json
  - Tenderdash host config dir
  - gateway SSL dir
  - Tenderdash Docker volume `_data`
  - Core `llmq`

## Breaking Changes

None.

## Checklist:
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Manual backup and restore workflows for HP masternodes with network/host targeting, batching, optional tooling install, S3 upload (AES256 or KMS), and single-host finalize step
  * On-host install/run actions and scripts to package/upload backups and perform restores, emitting backup metadata (host, id, S3 URI)

* **Documentation**
  * Detailed runbooks for backup, restore, and single-node recovery with examples and remediation steps

* **Bug Fixes**
  * Fixed user/group handling and tightened guard conditions

* **Chores**
  * Added ignore pattern for local tooling and a small package to setup tasks
<!-- end of auto-generated comment: release notes by coderabbit.ai -->