### PR TITLE
Fix platform destroy Docker cleanup

### DIFF
--- a/ansible/roles/kill_platform/tasks/main.yml
+++ b/ansible/roles/kill_platform/tasks/main.yml
@@ -20,9 +20,36 @@
   when:
     - inventory_hostname not in groups["hp_masternodes"]
 
+- name: Prune stopped platform containers (dashmate)
+  community.docker.docker_prune:
+    containers: true
+    containers_filters:
+      label:
+        - "com.docker.compose.project=dashmate_{{ dash_network_name }}"
+      "label!":
+        - "com.docker.compose.service=core"
+    images: false
+    networks: false
+    volumes: false
+    builder_cache: false
+  when:
+    - inventory_hostname in groups["hp_masternodes"]
+
+- name: Prune stopped platform containers (seeds)
+  community.docker.docker_prune:
+    containers: true
+    containers_filters:
+      label:
+        - "com.docker.compose.project={{ tenderdash_compose_project_name }}"
+    images: false
+    networks: false
+    volumes: false
+    builder_cache: false
+  when:
+    - inventory_hostname not in groups["hp_masternodes"]
+
 - name: Prune only dangling Docker images
   community.docker.docker_prune:
-    # Keep stopped Core containers and core_data volumes intact on platform-only destroy.
     containers: false
     images: true
     images_filters:

--- a/ansible/roles/kill_platform/tasks/main.yml
+++ b/ansible/roles/kill_platform/tasks/main.yml
@@ -30,3 +30,47 @@
     networks: true
     volumes: false
     builder_cache: true
+
+- name: Check for remaining platform Docker resources
+  ansible.builtin.shell: |
+    set -o pipefail
+
+    if [ "{{ inventory_hostname in groups['hp_masternodes'] }}" = "True" ]; then
+      project="dashmate_{{ dash_network_name }}"
+
+      docker ps -a --format '{{ "{{" }}.Names{{ "}}" }}' |
+        grep -E "^${project}-" |
+        grep -Ev "^${project}-core-1$" |
+        sed 's/^/container: /' || true
+
+      docker volume ls --format '{{ "{{" }}.Name{{ "}}" }}' |
+        grep -E "^${project}_" |
+        grep -Ev "^${project}_core_data$" |
+        sed 's/^/volume: /' || true
+
+      docker network ls --format '{{ "{{" }}.Name{{ "}}" }}' |
+        grep -E "^${project}_" |
+        sed 's/^/network: /' || true
+    else
+      docker ps -a --format '{{ "{{" }}.Names{{ "}}" }}' |
+        grep -E '^tenderdash$' |
+        sed 's/^/container: /' || true
+
+      docker network ls --format '{{ "{{" }}.Name{{ "}}" }}' |
+        grep -E '^tenderdash_' |
+        sed 's/^/network: /' || true
+    fi
+  args:
+    executable: /bin/bash
+  register: platform_docker_leftovers
+  changed_when: false
+
+- name: Report platform Docker cleanup status
+  ansible.builtin.debug:
+    msg: |
+      {% if platform_docker_leftovers.stdout_lines | length > 0 %}
+      Remaining platform Docker resources after platform destroy on {{ inventory_hostname }}:
+      {{ platform_docker_leftovers.stdout }}
+      {% else %}
+      No remaining platform Docker containers, volumes, or networks after platform destroy on {{ inventory_hostname }}.
+      {% endif %}

--- a/ansible/roles/kill_platform/tasks/main.yml
+++ b/ansible/roles/kill_platform/tasks/main.yml
@@ -20,45 +20,50 @@
   when:
     - inventory_hostname not in groups["hp_masternodes"]
 
-- name: Prune only safe dangling Docker data
+- name: Prune only dangling Docker images
   community.docker.docker_prune:
     # Keep stopped Core containers and core_data volumes intact on platform-only destroy.
     containers: false
     images: true
     images_filters:
       dangling: true
-    networks: true
+    networks: false
     volumes: false
-    builder_cache: true
+    builder_cache: false
 
 - name: Check for remaining platform Docker resources
   ansible.builtin.shell: |
-    set -o pipefail
+    set -euo pipefail
 
-    if [ "{{ inventory_hostname in groups['hp_masternodes'] }}" = "True" ]; then
+    print_matching() {
+      local label="$1"
+      local pattern="$2"
+      local exclude="${3:-}"
+
+      awk -v label="$label" -v pattern="$pattern" -v exclude="$exclude" '
+        $0 ~ pattern && (exclude == "" || $0 !~ exclude) {
+          print label ": " $0
+        }
+      '
+    }
+
+    if [ "{{ inventory_hostname in groups.get('hp_masternodes', []) }}" = "True" ]; then
       project="dashmate_{{ dash_network_name }}"
 
       docker ps -a --format '{{ "{{" }}.Names{{ "}}" }}' |
-        grep -E "^${project}-" |
-        grep -Ev "^${project}-core-1$" |
-        sed 's/^/container: /' || true
+        print_matching "container" "^${project}-" "^${project}-core-1$"
 
       docker volume ls --format '{{ "{{" }}.Name{{ "}}" }}' |
-        grep -E "^${project}_" |
-        grep -Ev "^${project}_core_data$" |
-        sed 's/^/volume: /' || true
+        print_matching "volume" "^${project}_" "^${project}_core_data$"
 
       docker network ls --format '{{ "{{" }}.Name{{ "}}" }}' |
-        grep -E "^${project}_" |
-        sed 's/^/network: /' || true
+        print_matching "network" "^${project}_" "^${project}_default$"
     else
       docker ps -a --format '{{ "{{" }}.Names{{ "}}" }}' |
-        grep -E '^tenderdash$' |
-        sed 's/^/container: /' || true
+        print_matching "container" '^tenderdash$'
 
       docker network ls --format '{{ "{{" }}.Name{{ "}}" }}' |
-        grep -E '^tenderdash_' |
-        sed 's/^/network: /' || true
+        print_matching "network" '^tenderdash_'
     fi
   args:
     executable: /bin/bash

--- a/ansible/roles/kill_platform/tasks/main.yml
+++ b/ansible/roles/kill_platform/tasks/main.yml
@@ -20,12 +20,13 @@
   when:
     - inventory_hostname not in groups["hp_masternodes"]
 
-- name: Remove any remaining docker data
+- name: Prune only safe dangling Docker data
   community.docker.docker_prune:
-    containers: true
+    # Keep stopped Core containers and core_data volumes intact on platform-only destroy.
+    containers: false
     images: true
     images_filters:
-      dangling: false
+      dangling: true
     networks: true
-    volumes: true
+    volumes: false
     builder_cache: true


### PR DESCRIPTION
## What changed

Make platform-only destroy clean up platform resources without touching Core.

- Run `dashmate reset --platform --force --hard` as before.
- Prune stopped dashmate platform containers by Docker compose label:
  - include `com.docker.compose.project=dashmate_<network>`
  - exclude `com.docker.compose.service=core`
- Prune stopped seed tenderdash containers by compose project label.
- Do not prune volumes.
- Do not prune Docker networks.
- Do not prune builder cache.
- Only prune dangling images.
- After cleanup, report any remaining platform Docker containers, volumes, or networks in Ansible output.

## Why

`./bin/destroy -t=platform <network>` previously ran a host-wide Docker prune after platform reset. If Core was stopped at that moment, Docker could remove the stopped Core container, making a platform-only destroy behave like a wider node wipe.

The cleanup still needs to be useful, so it now uses Docker labels to remove stopped platform containers while explicitly excluding Core.

## Validation

- Ran `ansible-playbook --syntax-check` for `destroy.yml` with `target=platform` against the testnet inventory/config.
- Verified live dashmate compose labels on `devnet-paloma` HPMN containers:
  - Core: `com.docker.compose.project=dashmate_devnet-paloma`, `com.docker.compose.service=core`
  - Platform containers use the same project label with non-core service labels.
