### PR TITLE
Fix testnet platform metrics ports

### DIFF
--- a/ansible/roles/dashmate/defaults/main.yml
+++ b/ansible/roles/dashmate/defaults/main.yml
@@ -24,12 +24,13 @@ dashmate_platform_gateway_upstreams_dapi_json_rpc_max_requests: 10000
 dashmate_platform_gateway_upstreams_drive_grpc_max_requests: 10000
 dashmate_platform_gateway_upstreams_rs_dapi_max_requests: 10000
 dashmate_platform_gateway_metrics_enabled: false
-dashmate_platform_gateway_metrics_port: 9090
+dashmate_platform_gateway_metrics_port: "{{ 19090 if (dash_network | default('')) == 'testnet' else 9090 }}"
+dashmate_platform_gateway_admin_port: "{{ 19901 if (dash_network | default('')) == 'testnet' else 9901 }}"
 dashmate_platform_gateway_rate_limiter_enabled: true
 dashmate_platform_gateway_rate_limiter_docker_image: "envoyproxy/ratelimit:3fcc3609"
 dashmate_platform_gateway_rate_limiter_metrics_enabled: false
 dashmate_platform_gateway_rate_limiter_metrics_docker_image: "prom/statsd-exporter:v0.26.1"
-dashmate_platform_gateway_rate_limiter_metrics_port: 9102
+dashmate_platform_gateway_rate_limiter_metrics_port: "{{ 19102 if (dash_network | default('')) == 'testnet' else 9102 }}"
 dashmate_platform_gateway_rate_limiter_unit: "minute"
 dashmate_platform_gateway_rate_limiter_requests_per_unit: 150
 
@@ -48,7 +49,8 @@ dashmate_platform_dapi_rs_dapi_log_json_format: false
 dashmate_platform_dapi_rs_dapi_access_log_path:
 dashmate_platform_dapi_rs_dapi_access_log_format: "combined"
 dashmate_platform_drive_abci_metrics_enabled: false
-dashmate_platform_drive_abci_metrics_port: 29090
+dashmate_platform_drive_abci_metrics_port: "{{ 39090 if (dash_network | default('')) == 'testnet' else 29090 }}"
+dashmate_platform_drive_abci_tokio_console_port: "{{ 16669 if (dash_network | default('')) == 'testnet' else 6669 }}"
 dashmate_platform_drive_tenderdash_p2p_flush_throttle_timeout: "100ms"
 dashmate_platform_drive_tenderdash_p2p_max_packet_msg_payload_size: 10240
 dashmate_platform_drive_tenderdash_p2p_send_rate: 5120000
@@ -87,7 +89,7 @@ dashmate_core_rpc_drive_consensus_password:
 dashmate_core_rpc_drive_check_tx_password:
 dashmate_core_rpc_tenderdash_password:
 platform_drive_grovedb_visualizer_enabled: false
-platform_drive_grovedb_visualizer_port: 8083
+platform_drive_grovedb_visualizer_port: "{{ 18083 if (dash_network | default('')) == 'testnet' else 8083 }}"
 initial_platform_protocol_version:
 
 dashmate_platform_quorum_list_enabled: false

--- a/ansible/roles/dashmate/templates/dashmate.json.j2
+++ b/ansible/roles/dashmate/templates/dashmate.json.j2
@@ -197,7 +197,7 @@
           "admin": {
             "enabled": {% if dashmate_platform_gateway_metrics_enabled %}true{% else %}false{% endif %},
             "host": "127.0.0.1",
-            "port": 9901
+            "port": {{ dashmate_platform_gateway_admin_port }}
           },
           "listeners": {
             "dapiAndDrive": {
@@ -324,7 +324,7 @@
             "tokioConsole": {
               "enabled": false,
               "host": "127.0.0.1",
-              "port": 6669,
+              "port": {{ dashmate_platform_drive_abci_tokio_console_port }},
               "retention": 180
             },
             "validatorSet": {

--- a/ansible/roles/metrics/templates/prometheus.yml.j2
+++ b/ansible/roles/metrics/templates/prometheus.yml.j2
@@ -57,7 +57,7 @@ scrape_configs:
     static_configs:
       - targets:
 {% for hp_name in hp_nodes %}
-        - "{{ hostvars[hp_name]['private_ip'] }}:9090"
+        - "{{ hostvars[hp_name]['private_ip'] }}:{{ dashmate_platform_gateway_metrics_port }}"
 {% endfor %}
         labels:
           cluster: "hp_masternodes"
@@ -71,7 +71,7 @@ scrape_configs:
     static_configs:
       - targets:
 {% for hp_name in hp_nodes %}
-        - "{{ hostvars[hp_name]['private_ip'] }}:9102"
+        - "{{ hostvars[hp_name]['private_ip'] }}:{{ dashmate_platform_gateway_rate_limiter_metrics_port }}"
 {% endfor %}
         labels:
           cluster: "hp_masternodes"
@@ -85,7 +85,7 @@ scrape_configs:
     static_configs:
       - targets:
 {% for hp_name in hp_nodes %}
-        - "{{ hostvars[hp_name]['private_ip'] }}:29090"
+        - "{{ hostvars[hp_name]['private_ip'] }}:{{ dashmate_platform_drive_abci_metrics_port }}"
 {% endfor %}
         labels:
           cluster: "hp_masternodes"

--- a/terraform/aws/security_groups.tf
+++ b/terraform/aws/security_groups.tf
@@ -369,35 +369,56 @@ resource "aws_security_group" "hp_masternode" {
     ])
   }
 
-  # Add ingress rule for port 9090
+  # Gateway metrics
   ingress {
     from_port   = 9090
     to_port     = 9090
     protocol    = "tcp"
-    description = "Internal service on port 9090"
+    description = "Gateway metrics"
     cidr_blocks = ["10.0.0.0/16"]
- }
+  }
 
-# Add ingress rule for port 9102
+  ingress {
+    from_port   = 19090
+    to_port     = 19090
+    protocol    = "tcp"
+    description = "Gateway metrics testnet"
+    cidr_blocks = ["10.0.0.0/16"]
+  }
+
+  # Gateway rate limiter metrics
   ingress {
     from_port   = 9102
     to_port     = 9102
     protocol    = "tcp"
-    description = "Internal service on port 9102"
+    description = "Gateway rate limiter metrics"
     cidr_blocks = ["10.0.0.0/16"]
   }
 
- # Add ingress rule for port 29090
+  ingress {
+    from_port   = 19102
+    to_port     = 19102
+    protocol    = "tcp"
+    description = "Gateway rate limiter metrics testnet"
+    cidr_blocks = ["10.0.0.0/16"]
+  }
+
+  # Drive ABCI metrics
   ingress {
     from_port   = 29090
     to_port     = 29090
     protocol    = "tcp"
-    description = "Internal service on port 9102"
+    description = "Drive ABCI metrics"
     cidr_blocks = ["10.0.0.0/16"]
   }
 
-
-
+  ingress {
+    from_port   = 39090
+    to_port     = 39090
+    protocol    = "tcp"
+    description = "Drive ABCI metrics testnet"
+    cidr_blocks = ["10.0.0.0/16"]
+  }
 
   # Tendermint RPC
   ingress {


### PR DESCRIPTION
## Summary
- render shifted platform service ports for testnet by default while keeping devnet/mainnet on existing ports
- make Prometheus scrape config use the same dashmate port variables instead of hardcoded base ports
- keep both base and shifted metrics ports open in the HPMN security group for mixed/transition states

## Why
Recent testnet deploys rendered some HPMNs with base ports (`9090`, `9102`, `29090`) while older nodes still used shifted testnet ports (`19090`, `19102`, `39090`), which caused Prometheus target drift and alerts.

## Validation
- `ansible-playbook --syntax-check ... deploy.yml --tags full_deploy` against testnet config
- rendered dashmate defaults locally for `dash_network=testnet` and `dash_network=devnet`
- `git diff --check`

Note: `terraform fmt -check security_groups.tf` still reports pre-existing whitespace-only formatting drift in that file outside this patch; I did not run broad formatting to avoid unrelated churn.